### PR TITLE
Add fields and flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ geocodio geocode "1600 Pennsylvania Ave NW, Washington DC"
 Geocodio can return additional data like timezone, congressional district, census data, and more. Specify fields with the `--fields` flag:
 
 ```bash
-geocodio geocode "1600 Pennsylvania Ave NW, Washington DC" --fields timezone,cd
+geocodio geocode "30 Rockefeller Plaza, New York NY" --fields timezone,cd
 ```
 
 > [!NOTE]
@@ -183,7 +183,7 @@ The coordinates file should have one `lat,lng` pair per line:
 Get only field appends (timezone, census data, etc.) for coordinates without reverse geocoding an address:
 
 ```bash
-geocodio reverse "38.8976,-77.0365" --skip-geocoding --fields timezone,cd
+geocodio reverse "40.7588,-73.9788" --skip-geocoding --fields timezone,cd
 ```
 
 **With inline distance calculations:**

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,244 @@
+package main_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	geocli "github.com/geocodio/geocodio-cli/internal/cli"
+)
+
+// runCLI runs the CLI with the given args against a test server.
+// Returns stdout output and any error.
+func runCLI(t *testing.T, server *httptest.Server, args ...string) (string, error) {
+	t.Helper()
+
+	fullArgs := []string{"geocodio", "--base-url", server.URL, "--api-key", "test-key", "--no-color"}
+	fullArgs = append(fullArgs, args...)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	app := geocli.NewApp()
+	err := app.Run(context.Background(), fullArgs)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	return buf.String(), err
+}
+
+// loadFixture reads a JSON fixture file from testdata/.
+func loadFixture(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("failed to load fixture %s: %v", name, err)
+	}
+	return string(data)
+}
+
+// newFixtureServer creates a test server that serves a fixture for a given path.
+func newFixtureServer(t *testing.T, pathToFixture map[string]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for path, fixture := range pathToFixture {
+			if strings.Contains(r.URL.Path, path) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(200)
+				w.Write([]byte(fixture))
+				return
+			}
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+		w.WriteHeader(404)
+	}))
+}
+
+// README Example: geocodio geocode "1600 Pennsylvania Ave NW, Washington DC"
+func TestIntegration_GeocodeSimple(t *testing.T) {
+	server := newFixtureServer(t, map[string]string{
+		"/geocode": loadFixture(t, "geocode_simple.json"),
+	})
+	defer server.Close()
+
+	output, err := runCLI(t, server, "geocode", "1600 Pennsylvania Ave NW, Washington DC")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, output, "1600 Pennsylvania Ave NW, Washington, DC 20500")
+	assertContains(t, output, "38.8976750")
+	assertContains(t, output, "rooftop")
+	assertContains(t, output, "Statewide (City of Washington)")
+}
+
+// README Example: geocodio geocode "30 Rockefeller Plaza, New York NY" --fields timezone,cd
+func TestIntegration_GeocodeWithFields(t *testing.T) {
+	server := newFixtureServer(t, map[string]string{
+		"/geocode": loadFixture(t, "geocode_fields.json"),
+	})
+	defer server.Close()
+
+	output, err := runCLI(t, server, "geocode", "30 Rockefeller Plaza, New York NY", "--fields", "timezone,cd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, output, "30 Rockefeller Plz, New York, NY 10112")
+	assertContains(t, output, "Timezone")
+	assertContains(t, output, "America/New_York")
+	assertContains(t, output, "Congressional District")
+	assertContains(t, output, "Congressional District 12")
+}
+
+// README Example: geocodio geocode "1600 Pennsylvania Ave NW, Washington DC" --destinations "New York" --destinations "Boston"
+func TestIntegration_GeocodeWithDestinations(t *testing.T) {
+	server := newFixtureServer(t, map[string]string{
+		"/geocode": loadFixture(t, "geocode_destinations.json"),
+	})
+	defer server.Close()
+
+	output, err := runCLI(t, server, "geocode", "1600 Pennsylvania Ave NW, Washington DC", "-d", "New York", "-d", "Boston")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, output, "Distances:")
+	assertContains(t, output, "New York, NY 10001")
+	assertContains(t, output, "Boston, MA 02106")
+	assertContains(t, output, "206.2 miles")
+	assertContains(t, output, "393.7 miles")
+}
+
+// README Example: geocodio geocode "1600 Pennsylvania Ave NW, Washington DC" --destinations "New York" --distance-mode driving
+func TestIntegration_GeocodeWithDrivingDistance(t *testing.T) {
+	server := newFixtureServer(t, map[string]string{
+		"/geocode": loadFixture(t, "geocode_driving.json"),
+	})
+	defer server.Close()
+
+	output, err := runCLI(t, server, "geocode", "1600 Pennsylvania Ave NW, Washington DC", "-d", "New York", "--distance-mode", "driving")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, output, "227.2 miles")
+	assertContains(t, output, "288 minutes")
+}
+
+// README Example: geocodio geocode "1600 Pennsylvania Ave NW, Washington DC" --show-address-key
+func TestIntegration_GeocodeShowAddressKey(t *testing.T) {
+	server := newFixtureServer(t, map[string]string{
+		"/geocode": loadFixture(t, "geocode_address_key.json"),
+	})
+	defer server.Close()
+
+	output, err := runCLI(t, server, "geocode", "1600 Pennsylvania Ave NW, Washington DC", "--show-address-key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, output, "Address Key")
+	assertContains(t, output, "gcod_usnqu2qtyk7ac38dlpzanec598p2c")
+}
+
+// README Example: geocodio reverse "38.8976,-77.0365"
+func TestIntegration_ReverseGeocode(t *testing.T) {
+	server := newFixtureServer(t, map[string]string{
+		"/reverse": loadFixture(t, "reverse_simple.json"),
+	})
+	defer server.Close()
+
+	output, err := runCLI(t, server, "reverse", "38.8976,-77.0365")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, output, "1600 Pennsylvania Ave NW, Washington, DC 20500")
+	assertContains(t, output, "rooftop")
+}
+
+// README Example: geocodio reverse "40.7588,-73.9788" --skip-geocoding --fields timezone,cd
+func TestIntegration_ReverseSkipGeocoding(t *testing.T) {
+	server := newFixtureServer(t, map[string]string{
+		"/reverse": loadFixture(t, "reverse_skip_fields.json"),
+	})
+	defer server.Close()
+
+	output, err := runCLI(t, server, "reverse", "40.7588,-73.9788", "--skip-geocoding", "--fields", "timezone,cd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, output, "Timezone")
+	assertContains(t, output, "America/New_York")
+	assertContains(t, output, "Congressional District")
+	assertContains(t, output, "Congressional District 12")
+}
+
+// README Example: geocodio distance "Washington DC" "New York"
+func TestIntegration_Distance(t *testing.T) {
+	server := newFixtureServer(t, map[string]string{
+		"/distance": loadFixture(t, "distance_simple.json"),
+	})
+	defer server.Close()
+
+	output, err := runCLI(t, server, "distance", "Washington DC", "New York")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, output, "Washington, DC 20001")
+	assertContains(t, output, "New York, NY 10001")
+	assertContains(t, output, "226.6 miles")
+	assertContains(t, output, "284 minutes")
+}
+
+// README Example: geocodio distance "Washington DC" "New York" "Boston" "Philadelphia"
+func TestIntegration_DistanceMultiple(t *testing.T) {
+	server := newFixtureServer(t, map[string]string{
+		"/distance": loadFixture(t, "distance_multiple.json"),
+	})
+	defer server.Close()
+
+	output, err := runCLI(t, server, "distance", "Washington DC", "New York", "Boston", "Philadelphia")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, output, "New York, NY 10001")
+	assertContains(t, output, "Boston, MA 02106")
+	assertContains(t, output, "Philadelphia, PA 19101")
+}
+
+// README Example: geocodio distance "Washington DC" "New York" --mode driving --units km
+func TestIntegration_DistanceWithUnitsKm(t *testing.T) {
+	server := newFixtureServer(t, map[string]string{
+		"/distance": loadFixture(t, "distance_km.json"),
+	})
+	defer server.Close()
+
+	output, err := runCLI(t, server, "distance", "Washington DC", "New York", "--mode", "driving", "--units", "km")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertContains(t, output, "364.7 km (226.6 miles)")
+}
+
+func assertContains(t *testing.T, output, want string) {
+	t.Helper()
+	if !strings.Contains(output, want) {
+		t.Errorf("output missing %q:\n%s", want, output)
+	}
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -32,7 +32,7 @@ func runCLI(t *testing.T, server *httptest.Server, args ...string) (string, erro
 	os.Stdout = oldStdout
 
 	var buf bytes.Buffer
-	buf.ReadFrom(r)
+	_, _ = buf.ReadFrom(r)
 
 	return buf.String(), err
 }
@@ -55,7 +55,7 @@ func newFixtureServer(t *testing.T, pathToFixture map[string]string) *httptest.S
 			if strings.Contains(r.URL.Path, path) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(200)
-				w.Write([]byte(fixture))
+				_, _ = w.Write([]byte(fixture))
 				return
 			}
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,10 @@
 package cli
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -223,6 +227,55 @@ func TestReadLines(t *testing.T) {
 			t.Error("readLines() expected error for non-existent file, got nil")
 		}
 	})
+}
+
+func TestGeocodeWithCommaDestination(t *testing.T) {
+	const wantDestination = "1600 Pennsylvania Ave NW, Washington DC"
+
+	var sawRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+
+		if r.URL.Path != "/geocode" {
+			t.Errorf("path = %q, want %q", r.URL.Path, "/geocode")
+		}
+
+		destinations := r.URL.Query()["destinations[]"]
+		if len(destinations) != 1 {
+			t.Errorf("expected 1 destination, got %d: %v", len(destinations), destinations)
+		} else if destinations[0] != wantDestination {
+			t.Errorf("destination = %q, want %q", destinations[0], wantDestination)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"results": [{
+				"formatted_address": "1 Main St, Washington, DC 20001",
+				"location": {"lat": 38.9000, "lng": -77.0000},
+				"accuracy": 1,
+				"accuracy_type": "rooftop",
+				"destinations": [{
+					"query": "1600 Pennsylvania Ave NW, Washington DC",
+					"distance_miles": 1.2
+				}]
+			}]
+		}`)
+	}))
+	defer server.Close()
+
+	err := Run(context.Background(), []string{
+		"geocodio",
+		"--api-key", "test-api-key",
+		"--base-url", server.URL,
+		"geocode", "1 Main St",
+		"--destinations", wantDestination,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !sawRequest {
+		t.Fatal("expected geocode request")
+	}
 }
 
 func TestNewApp(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -230,7 +230,10 @@ func TestReadLines(t *testing.T) {
 }
 
 func TestGeocodeWithCommaDestination(t *testing.T) {
-	const wantDestination = "1600 Pennsylvania Ave NW, Washington DC"
+	wantDestinations := []string{
+		"1600 Pennsylvania Ave NW, Washington DC",
+		"350 Fifth Ave, New York, NY",
+	}
 
 	var sawRequest bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -241,10 +244,13 @@ func TestGeocodeWithCommaDestination(t *testing.T) {
 		}
 
 		destinations := r.URL.Query()["destinations[]"]
-		if len(destinations) != 1 {
-			t.Errorf("expected 1 destination, got %d: %v", len(destinations), destinations)
-		} else if destinations[0] != wantDestination {
-			t.Errorf("destination = %q, want %q", destinations[0], wantDestination)
+		if len(destinations) != len(wantDestinations) {
+			t.Errorf("expected %d destinations, got %d: %v", len(wantDestinations), len(destinations), destinations)
+		}
+		for i, want := range wantDestinations {
+			if i < len(destinations) && destinations[i] != want {
+				t.Errorf("destination[%d] = %q, want %q", i, destinations[i], want)
+			}
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -268,7 +274,8 @@ func TestGeocodeWithCommaDestination(t *testing.T) {
 		"--api-key", "test-api-key",
 		"--base-url", server.URL,
 		"geocode", "1 Main St",
-		"--destinations", wantDestination,
+		"-d", wantDestinations[0],
+		"-d", wantDestinations[1],
 	})
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)

--- a/internal/cli/destinations.go
+++ b/internal/cli/destinations.go
@@ -61,7 +61,8 @@ func destinationFlags() []cli.Flag {
 func parseDestinationParams(cmd *cli.Command) api.DestinationParams {
 	dests := cmd.StringSlice("destinations")
 
-	// Also support comma-separated destinations in a single flag value
+	// Also support semicolon-separated destinations in a single flag value.
+	// Commas are valid inside street addresses and coordinates.
 	var expanded []string
 	for _, d := range dests {
 		if strings.Contains(d, ";") {

--- a/internal/cli/destinations_test.go
+++ b/internal/cli/destinations_test.go
@@ -4,6 +4,82 @@ import (
 	"testing"
 )
 
+func TestAppendCountry(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		country string
+		want    string
+	}{
+		{
+			name:    "appends Canada",
+			address: "Ottawa ON",
+			country: "Canada",
+			want:    "Ottawa ON, Canada",
+		},
+		{
+			name:    "appends Canada case-insensitive",
+			address: "Ottawa ON",
+			country: "canada",
+			want:    "Ottawa ON, Canada",
+		},
+		{
+			name:    "appends USA",
+			address: "Springfield IL",
+			country: "USA",
+			want:    "Springfield IL, USA",
+		},
+		{
+			name:    "no country flag",
+			address: "Ottawa ON",
+			country: "",
+			want:    "Ottawa ON",
+		},
+		{
+			name:    "invalid country ignored",
+			address: "Ottawa ON",
+			country: "CA",
+			want:    "Ottawa ON",
+		},
+		{
+			name:    "invalid country US ignored",
+			address: "Ottawa ON",
+			country: "US",
+			want:    "Ottawa ON",
+		},
+		{
+			name:    "address already contains country",
+			address: "Ottawa Ontario Canada",
+			country: "Canada",
+			want:    "Ottawa Ontario Canada",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendCountry(tt.address, tt.country)
+			if got != tt.want {
+				t.Errorf("appendCountry(%q, %q) = %q, want %q", tt.address, tt.country, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendCountryToSlice(t *testing.T) {
+	addresses := []string{"Ottawa ON", "Toronto ON"}
+	result := appendCountryToAll(addresses, "Canada")
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(result))
+	}
+	if result[0] != "Ottawa ON, Canada" {
+		t.Errorf("result[0] = %q, want %q", result[0], "Ottawa ON, Canada")
+	}
+	if result[1] != "Toronto ON, Canada" {
+		t.Errorf("result[1] = %q, want %q", result[1], "Toronto ON, Canada")
+	}
+}
+
 func TestDestinationFlags(t *testing.T) {
 	flags := destinationFlags()
 

--- a/internal/cli/distance.go
+++ b/internal/cli/distance.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/geocodio/geocodio-cli/internal/api"
+	"github.com/geocodio/geocodio-cli/internal/output"
 	"github.com/geocodio/geocodio-cli/internal/ui"
 	"github.com/urfave/cli/v3"
 )
@@ -33,7 +34,7 @@ func distanceCmd() *cli.Command {
 }
 
 func distanceAction(ctx context.Context, cmd *cli.Command) error {
-	app, err := newApp(cmd)
+	app, err := newApp(cmd, output.Options{Units: cmd.String("units")})
 	if err != nil {
 		return err
 	}
@@ -89,7 +90,7 @@ func distanceMatrixCmd() *cli.Command {
 }
 
 func distanceMatrixAction(ctx context.Context, cmd *cli.Command) error {
-	app, err := newApp(cmd)
+	app, err := newApp(cmd, output.Options{Units: cmd.String("units")})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/distance.go
+++ b/internal/cli/distance.go
@@ -3,12 +3,53 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/geocodio/geocodio-cli/internal/api"
 	"github.com/geocodio/geocodio-cli/internal/output"
 	"github.com/geocodio/geocodio-cli/internal/ui"
 	"github.com/urfave/cli/v3"
 )
+
+// appendCountry appends the country to an address if it's not already present.
+// Only accepts "USA" or "Canada" (case-insensitive). Other values are ignored.
+func appendCountry(address, country string) string {
+	if country == "" {
+		return address
+	}
+	normalized := normalizeCountry(country)
+	if normalized == "" {
+		return address
+	}
+	if strings.Contains(strings.ToLower(address), strings.ToLower(normalized)) {
+		return address
+	}
+	return address + ", " + normalized
+}
+
+// normalizeCountry returns the accepted country string or empty if invalid.
+func normalizeCountry(country string) string {
+	switch strings.ToLower(country) {
+	case "usa":
+		return "USA"
+	case "canada":
+		return "Canada"
+	default:
+		return ""
+	}
+}
+
+// appendCountryToAll appends the country to each address in the slice.
+func appendCountryToAll(addresses []string, country string) []string {
+	if country == "" {
+		return addresses
+	}
+	result := make([]string, len(addresses))
+	for i, addr := range addresses {
+		result[i] = appendCountry(addr, country)
+	}
+	return result
+}
 
 func distanceCmd() *cli.Command {
 	return &cli.Command{
@@ -28,6 +69,11 @@ func distanceCmd() *cli.Command {
 				Usage:   "Distance units: miles or km",
 				Value:   "miles",
 			},
+			&cli.StringFlag{
+				Name:    "country",
+				Aliases: []string{"c"},
+				Usage:   "Country to append to addresses (e.g. Canada)",
+			},
 		},
 		Action: distanceAction,
 	}
@@ -44,8 +90,12 @@ func distanceAction(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	args := cmd.Args().Slice()
-	origin := args[0]
-	destinations := args[1:]
+	country := cmd.String("country")
+	if country != "" && normalizeCountry(country) == "" {
+		fmt.Fprintf(app.stderr, "Warning: %q is not a valid country. Accepted values are USA or Canada. Flag will be ignored.\n", country)
+	}
+	origin := appendCountry(args[0], country)
+	destinations := appendCountryToAll(args[1:], country)
 
 	resp, err := app.client.Distance(ctx, origin, destinations, cmd.String("mode"), cmd.String("units"))
 	if err != nil {
@@ -84,6 +134,11 @@ func distanceMatrixCmd() *cli.Command {
 				Usage:   "Distance units: miles or km",
 				Value:   "miles",
 			},
+			&cli.StringFlag{
+				Name:    "country",
+				Aliases: []string{"c"},
+				Usage:   "Country to append to addresses (e.g. Canada)",
+			},
 		},
 		Action: distanceMatrixAction,
 	}
@@ -113,6 +168,12 @@ func distanceMatrixAction(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("destinations file is empty")
 	}
 
+	country := cmd.String("country")
+	if country != "" && normalizeCountry(country) == "" {
+		fmt.Fprintf(app.stderr, "Warning: %q is not a valid country. Accepted values are USA or Canada. Flag will be ignored.\n", country)
+	}
+	origins = appendCountryToAll(origins, country)
+	destinations = appendCountryToAll(destinations, country)
 	mode := cmd.String("mode")
 	units := cmd.String("units")
 

--- a/internal/cli/geocode.go
+++ b/internal/cli/geocode.go
@@ -49,7 +49,7 @@ func geocodeCmd() *cli.Command {
 }
 
 func geocodeAction(ctx context.Context, cmd *cli.Command) error {
-	app, err := newApp(cmd, output.Options{ShowAddressKey: cmd.Bool("show-address-key")})
+	app, err := newApp(cmd, output.Options{ShowAddressKey: cmd.Bool("show-address-key"), Units: cmd.String("distance-units")})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/geocode.go
+++ b/internal/cli/geocode.go
@@ -15,9 +15,10 @@ import (
 
 func geocodeCmd() *cli.Command {
 	return &cli.Command{
-		Name:      "geocode",
-		Usage:     "Geocode an address",
-		ArgsUsage: "[address]",
+		Name:                      "geocode",
+		Usage:                     "Geocode an address",
+		ArgsUsage:                 "[address]",
+		DisableSliceFlagSeparator: true,
 		Flags: append([]cli.Flag{
 			&cli.StringFlag{
 				Name:    "batch",

--- a/internal/cli/reverse.go
+++ b/internal/cli/reverse.go
@@ -14,9 +14,10 @@ import (
 
 func reverseCmd() *cli.Command {
 	return &cli.Command{
-		Name:      "reverse",
-		Usage:     "Reverse geocode coordinates",
-		ArgsUsage: "<lat,lng>",
+		Name:                      "reverse",
+		Usage:                     "Reverse geocode coordinates",
+		ArgsUsage:                 "<lat,lng>",
+		DisableSliceFlagSeparator: true,
 		Flags: append([]cli.Flag{
 			&cli.StringFlag{
 				Name:    "batch",

--- a/internal/cli/reverse.go
+++ b/internal/cli/reverse.go
@@ -47,7 +47,7 @@ func reverseCmd() *cli.Command {
 }
 
 func reverseAction(ctx context.Context, cmd *cli.Command) error {
-	app, err := newApp(cmd, output.Options{ShowAddressKey: cmd.Bool("show-address-key")})
+	app, err := newApp(cmd, output.Options{ShowAddressKey: cmd.Bool("show-address-key"), Units: cmd.String("distance-units")})
 	if err != nil {
 		return err
 	}

--- a/internal/output/agent.go
+++ b/internal/output/agent.go
@@ -18,6 +18,13 @@ func NewAgent(w io.Writer, opts Options) *Agent {
 	return &Agent{w: w, opts: opts}
 }
 
+func (a *Agent) formatDistance(miles, km float64) string {
+	if a.opts.Units == "km" {
+		return fmt.Sprintf("%.1f km / %.1f mi", km, miles)
+	}
+	return fmt.Sprintf("%.1f mi / %.1f km", miles, km)
+}
+
 func (a *Agent) FormatGeocode(resp *api.GeocodeResponse) error {
 	if len(resp.Results) == 0 {
 		fmt.Fprintln(a.w, "No results found.")
@@ -87,8 +94,8 @@ func (a *Agent) writeResultTable(r *api.GeocodeResult) {
 				mins := float64(*d.DurationSeconds) / 60
 				duration = fmt.Sprintf("%.0f min", mins)
 			}
-			fmt.Fprintf(a.w, "| %s | %.1f mi / %.1f km | %s |\n",
-				destStr, d.DistanceMiles, d.DistanceKm, duration)
+			fmt.Fprintf(a.w, "| %s | %s | %s |\n",
+				destStr, a.formatDistance(d.DistanceMiles, d.DistanceKm), duration)
 		}
 	}
 }
@@ -149,8 +156,8 @@ func (a *Agent) FormatDistance(resp *api.DistanceResponse) error {
 			mins := float64(*d.DurationSeconds) / 60
 			duration = fmt.Sprintf("%.0f min", mins)
 		}
-		fmt.Fprintf(a.w, "| %s | %s | %.1f mi / %.1f km | %s |\n",
-			originAddr, destAddr, d.DistanceMiles, d.DistanceKm, duration)
+		fmt.Fprintf(a.w, "| %s | %s | %s | %s |\n",
+			originAddr, destAddr, a.formatDistance(d.DistanceMiles, d.DistanceKm), duration)
 	}
 	return nil
 }
@@ -188,8 +195,8 @@ func (a *Agent) FormatDistanceMatrix(resp *api.DistanceMatrixResponse) error {
 				mins := float64(*d.DurationSeconds) / 60
 				duration = fmt.Sprintf("%.0f min", mins)
 			}
-			fmt.Fprintf(a.w, "| %s | %.1f mi / %.1f km | %s |\n",
-				destStr, d.DistanceMiles, d.DistanceKm, duration)
+			fmt.Fprintf(a.w, "| %s | %s | %s |\n",
+				destStr, a.formatDistance(d.DistanceMiles, d.DistanceKm), duration)
 		}
 
 		if i < len(resp.Results)-1 {

--- a/internal/output/agent.go
+++ b/internal/output/agent.go
@@ -1,8 +1,10 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/geocodio/geocodio-cli/internal/api"
 )
@@ -48,6 +50,26 @@ func (a *Agent) writeResultTable(r *api.GeocodeResult) {
 	}
 	if a.opts.ShowAddressKey && r.StableAddressKey != "" {
 		fmt.Fprintf(a.w, "| Address Key | %s |\n", r.StableAddressKey)
+	}
+	if r.Fields != nil && len(*r.Fields) > 0 {
+		fmt.Fprintln(a.w)
+		fmt.Fprintln(a.w, "**Fields:**")
+		fmt.Fprintln(a.w)
+		fieldNames := make([]string, 0, len(*r.Fields))
+		for name := range *r.Fields {
+			fieldNames = append(fieldNames, name)
+		}
+		sort.Strings(fieldNames)
+		for _, name := range fieldNames {
+			val := (*r.Fields)[name]
+			fmt.Fprintf(a.w, "**%s:**\n\n", name)
+			data, err := json.MarshalIndent(val, "", "  ")
+			if err != nil {
+				fmt.Fprintf(a.w, "%v\n\n", val)
+			} else {
+				fmt.Fprintf(a.w, "```json\n%s\n```\n\n", string(data))
+			}
+		}
 	}
 	if len(r.Destinations) > 0 {
 		fmt.Fprintln(a.w)

--- a/internal/output/agent.go
+++ b/internal/output/agent.go
@@ -3,7 +3,6 @@ package output
 import (
 	"fmt"
 	"io"
-	"sort"
 
 	"github.com/geocodio/geocodio-cli/internal/api"
 )
@@ -49,35 +48,6 @@ func (a *Agent) writeResultTable(r *api.GeocodeResult) {
 	}
 	if a.opts.ShowAddressKey && r.StableAddressKey != "" {
 		fmt.Fprintf(a.w, "| Address Key | %s |\n", r.StableAddressKey)
-	}
-	if r.Fields != nil && len(*r.Fields) > 0 {
-		fmt.Fprintln(a.w)
-		fmt.Fprintln(a.w, "**Fields:**")
-		fmt.Fprintln(a.w)
-		fieldNames := make([]string, 0, len(*r.Fields))
-		for name := range *r.Fields {
-			fieldNames = append(fieldNames, name)
-		}
-		sort.Strings(fieldNames)
-		for _, name := range fieldNames {
-			val := (*r.Fields)[name]
-			if nested, ok := val.(map[string]interface{}); ok {
-				fmt.Fprintf(a.w, "**%s:**\n\n", name)
-				fmt.Fprintln(a.w, "| Key | Value |")
-				fmt.Fprintln(a.w, "|-----|-------|")
-				subKeys := make([]string, 0, len(nested))
-				for k := range nested {
-					subKeys = append(subKeys, k)
-				}
-				sort.Strings(subKeys)
-				for _, k := range subKeys {
-					fmt.Fprintf(a.w, "| %s | %v |\n", k, nested[k])
-				}
-				fmt.Fprintln(a.w)
-			} else {
-				fmt.Fprintf(a.w, "| %s | %v |\n", name, val)
-			}
-		}
 	}
 	if len(r.Destinations) > 0 {
 		fmt.Fprintln(a.w)

--- a/internal/output/agent.go
+++ b/internal/output/agent.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/geocodio/geocodio-cli/internal/api"
 )
@@ -48,6 +49,35 @@ func (a *Agent) writeResultTable(r *api.GeocodeResult) {
 	}
 	if a.opts.ShowAddressKey && r.StableAddressKey != "" {
 		fmt.Fprintf(a.w, "| Address Key | %s |\n", r.StableAddressKey)
+	}
+	if r.Fields != nil && len(*r.Fields) > 0 {
+		fmt.Fprintln(a.w)
+		fmt.Fprintln(a.w, "**Fields:**")
+		fmt.Fprintln(a.w)
+		fieldNames := make([]string, 0, len(*r.Fields))
+		for name := range *r.Fields {
+			fieldNames = append(fieldNames, name)
+		}
+		sort.Strings(fieldNames)
+		for _, name := range fieldNames {
+			val := (*r.Fields)[name]
+			if nested, ok := val.(map[string]interface{}); ok {
+				fmt.Fprintf(a.w, "**%s:**\n\n", name)
+				fmt.Fprintln(a.w, "| Key | Value |")
+				fmt.Fprintln(a.w, "|-----|-------|")
+				subKeys := make([]string, 0, len(nested))
+				for k := range nested {
+					subKeys = append(subKeys, k)
+				}
+				sort.Strings(subKeys)
+				for _, k := range subKeys {
+					fmt.Fprintf(a.w, "| %s | %v |\n", k, nested[k])
+				}
+				fmt.Fprintln(a.w)
+			} else {
+				fmt.Fprintf(a.w, "| %s | %v |\n", name, val)
+			}
+		}
 	}
 	if len(r.Destinations) > 0 {
 		fmt.Fprintln(a.w)

--- a/internal/output/agent_test.go
+++ b/internal/output/agent_test.go
@@ -167,6 +167,56 @@ func TestAgent_FormatGeocodeStableAddressKey(t *testing.T) {
 	})
 }
 
+func TestAgent_FormatGeocodeWithFields(t *testing.T) {
+	resp := &api.GeocodeResponse{
+		Results: []api.GeocodeResult{
+			{
+				FormattedAddress: "1600 Pennsylvania Ave NW, Washington, DC 20500",
+				Location:         api.Location{Lat: 38.897675, Lng: -77.036547},
+				Accuracy:         1.0,
+				AccuracyType:     "rooftop",
+				Fields: &api.Fields{
+					"timezone": map[string]interface{}{
+						"name":         "America/New_York",
+						"utc_offset":   float64(-5),
+						"observes_dst": true,
+						"abbreviation": "EST",
+					},
+					"congressional_districts": []interface{}{
+						map[string]interface{}{
+							"name":            "Congressional District 8",
+							"district_number": float64(8),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	a := NewAgent(&buf, Options{})
+
+	err := a.FormatGeocode(resp)
+	if err != nil {
+		t.Fatalf("FormatGeocode() error = %v", err)
+	}
+
+	output := buf.String()
+	wantContains := []string{
+		"**Fields:**",
+		"**timezone:**",
+		"America/New_York",
+		"**congressional_districts:**",
+		"Congressional District 8",
+		"```json",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
 func TestAgent_FormatBatchGeocode(t *testing.T) {
 	var buf bytes.Buffer
 	a := NewAgent(&buf, Options{})

--- a/internal/output/agent_test.go
+++ b/internal/output/agent_test.go
@@ -167,47 +167,6 @@ func TestAgent_FormatGeocodeStableAddressKey(t *testing.T) {
 	})
 }
 
-func TestAgent_FormatGeocodeWithFields(t *testing.T) {
-	resp := &api.GeocodeResponse{
-		Results: []api.GeocodeResult{
-			{
-				FormattedAddress: "1600 Pennsylvania Ave NW, Washington, DC 20500",
-				Location:         api.Location{Lat: 38.897675, Lng: -77.036547},
-				Accuracy:         1.0,
-				AccuracyType:     "rooftop",
-				Fields: &api.Fields{
-					"timezone": map[string]interface{}{
-						"name":         "America/New_York",
-						"utc_offset":   float64(-5),
-						"observes_dst": true,
-						"abbreviation": "EST",
-					},
-				},
-			},
-		},
-	}
-
-	var buf bytes.Buffer
-	a := NewAgent(&buf, Options{})
-
-	err := a.FormatGeocode(resp)
-	if err != nil {
-		t.Fatalf("FormatGeocode() error = %v", err)
-	}
-
-	output := buf.String()
-	wantContains := []string{
-		"Fields",
-		"timezone",
-		"America/New_York",
-	}
-	for _, want := range wantContains {
-		if !strings.Contains(output, want) {
-			t.Errorf("output missing %q:\n%s", want, output)
-		}
-	}
-}
-
 func TestAgent_FormatBatchGeocode(t *testing.T) {
 	var buf bytes.Buffer
 	a := NewAgent(&buf, Options{})

--- a/internal/output/agent_test.go
+++ b/internal/output/agent_test.go
@@ -167,6 +167,47 @@ func TestAgent_FormatGeocodeStableAddressKey(t *testing.T) {
 	})
 }
 
+func TestAgent_FormatGeocodeWithFields(t *testing.T) {
+	resp := &api.GeocodeResponse{
+		Results: []api.GeocodeResult{
+			{
+				FormattedAddress: "1600 Pennsylvania Ave NW, Washington, DC 20500",
+				Location:         api.Location{Lat: 38.897675, Lng: -77.036547},
+				Accuracy:         1.0,
+				AccuracyType:     "rooftop",
+				Fields: &api.Fields{
+					"timezone": map[string]interface{}{
+						"name":         "America/New_York",
+						"utc_offset":   float64(-5),
+						"observes_dst": true,
+						"abbreviation": "EST",
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	a := NewAgent(&buf, Options{})
+
+	err := a.FormatGeocode(resp)
+	if err != nil {
+		t.Fatalf("FormatGeocode() error = %v", err)
+	}
+
+	output := buf.String()
+	wantContains := []string{
+		"Fields",
+		"timezone",
+		"America/New_York",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
 func TestAgent_FormatBatchGeocode(t *testing.T) {
 	var buf bytes.Buffer
 	a := NewAgent(&buf, Options{})

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -35,6 +35,7 @@ type Formatter interface {
 // Options configures output formatting behavior.
 type Options struct {
 	ShowAddressKey bool
+	Units          string // "miles" or "km"
 }
 
 // New creates a new Formatter based on the specified mode and styling preference.

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -90,7 +90,7 @@ func (h *Human) formatResult(r *api.GeocodeResult, num, total int) {
 				destStr = d.Geocode.FormattedAddress
 			}
 			h.printField("To", destStr)
-			h.printField("Distance", fmt.Sprintf("%.1f miles (%.1f km)", d.DistanceMiles, d.DistanceKm))
+			h.printField("Distance", h.formatDistance(d.DistanceMiles, d.DistanceKm))
 			if d.DurationSeconds != nil {
 				mins := float64(*d.DurationSeconds) / 60
 				h.printField("Duration", fmt.Sprintf("%.0f minutes", mins))
@@ -107,6 +107,14 @@ func (h *Human) printField(label, value string) {
 	} else {
 		fmt.Fprintf(h.w, "  %-18s %s\n", label, value)
 	}
+}
+
+// formatDistance returns a distance string with the primary unit matching the user's preference.
+func (h *Human) formatDistance(miles, km float64) string {
+	if h.opts.Units == "km" {
+		return fmt.Sprintf("%.1f km (%.1f miles)", km, miles)
+	}
+	return fmt.Sprintf("%.1f miles (%.1f km)", miles, km)
 }
 
 // printJSON pretty-prints a value as indented JSON with the given prefix on each line.
@@ -281,7 +289,7 @@ func (h *Human) FormatDistance(resp *api.DistanceResponse) error {
 			destAddr = d.Geocode.FormattedAddress
 		}
 		h.printField("To", destAddr)
-		h.printField("Distance", fmt.Sprintf("%.1f miles (%.1f km)", d.DistanceMiles, d.DistanceKm))
+		h.printField("Distance", h.formatDistance(d.DistanceMiles, d.DistanceKm))
 		if d.DurationSeconds != nil {
 			mins := float64(*d.DurationSeconds) / 60
 			h.printField("Duration", fmt.Sprintf("%.0f minutes", mins))
@@ -320,7 +328,7 @@ func (h *Human) FormatDistanceMatrix(resp *api.DistanceMatrixResponse) error {
 				destStr = fmt.Sprintf("%.6f, %.6f", d.Location[0], d.Location[1])
 			}
 			h.printField("To", destStr)
-			h.printField("Distance", fmt.Sprintf("%.1f miles (%.1f km)", d.DistanceMiles, d.DistanceKm))
+			h.printField("Distance", h.formatDistance(d.DistanceMiles, d.DistanceKm))
 			if d.DurationSeconds != nil {
 				mins := float64(*d.DurationSeconds) / 60
 				h.printField("Duration", fmt.Sprintf("%.0f minutes", mins))

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -71,19 +72,13 @@ func (h *Human) formatResult(r *api.GeocodeResult, num, total int) {
 		sort.Strings(fieldNames)
 		for _, name := range fieldNames {
 			val := (*r.Fields)[name]
-			if nested, ok := val.(map[string]interface{}); ok {
-				fmt.Fprintf(h.w, "    %s\n", h.style(LabelStyle, name))
-				subKeys := make([]string, 0, len(nested))
-				for k := range nested {
-					subKeys = append(subKeys, k)
-				}
-				sort.Strings(subKeys)
-				for _, k := range subKeys {
-					fmt.Fprintf(h.w, "      %-18s %v\n", k, nested[k])
-				}
+			label, summary := fieldSummary(name, val)
+			if summary != "" {
+				h.printField(label, summary)
 			} else {
-				h.printField(name, fmt.Sprintf("%v", val))
+				h.printField(label, "")
 			}
+			h.printJSON(val, "      ")
 		}
 	}
 	if len(r.Destinations) > 0 {
@@ -112,6 +107,126 @@ func (h *Human) printField(label, value string) {
 	} else {
 		fmt.Fprintf(h.w, "  %-18s %s\n", label, value)
 	}
+}
+
+// printJSON pretty-prints a value as indented JSON with the given prefix on each line.
+func (h *Human) printJSON(val interface{}, prefix string) {
+	data, err := json.MarshalIndent(val, "", "  ")
+	if err != nil {
+		fmt.Fprintf(h.w, "%s%v\n", prefix, val)
+		return
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fmt.Fprintf(h.w, "%s%s\n", prefix, line)
+	}
+}
+
+// isFlat returns true if all values in the map are scalar (not maps or slices).
+func isFlat(m map[string]interface{}) bool {
+	for _, v := range m {
+		switch v.(type) {
+		case map[string]interface{}, []interface{}:
+			return false
+		}
+	}
+	return true
+}
+
+// fieldSummary returns a human-friendly label and summary value for a known field.
+// For unknown fields, it returns the raw key name and an empty summary.
+func fieldSummary(key string, val interface{}) (label, summary string) {
+	switch key {
+	case "congressional_districts":
+		label = "Congressional District"
+		summary = extractFromArray(val, "name")
+	case "state_legislative_districts":
+		label = "State Legislature"
+		if m, ok := val.(map[string]interface{}); ok {
+			house := extractFromArray(m["house"], "name")
+			senate := extractFromArray(m["senate"], "name")
+			parts := []string{}
+			if house != "" {
+				parts = append(parts, house)
+			}
+			if senate != "" {
+				parts = append(parts, senate)
+			}
+			summary = strings.Join(parts, ", ")
+		}
+	case "school_districts":
+		label = "School District"
+		if m, ok := val.(map[string]interface{}); ok {
+			for _, sub := range []string{"unified", "elementary", "secondary"} {
+				if v, ok := m[sub]; ok {
+					if name := extractName(v); name != "" {
+						summary = name
+						break
+					}
+				}
+			}
+		}
+	case "census":
+		label = "Census"
+		if m, ok := val.(map[string]interface{}); ok {
+			parts := []string{}
+			if bc, ok := m["block_code"].(string); ok {
+				parts = append(parts, "Block: "+bc)
+			}
+			if fips, ok := m["full_fips"].(string); ok {
+				parts = append(parts, "FIPS: "+fips)
+			}
+			summary = strings.Join(parts, ", ")
+		}
+	case "timezone":
+		label = "Timezone"
+		summary = extractName(val)
+	case "zip4":
+		label = "USPS ZIP+4"
+		if arr, ok := val.([]interface{}); ok && len(arr) > 0 {
+			if m, ok := arr[0].(map[string]interface{}); ok {
+				if p4, ok := m["plus4"].([]interface{}); ok && len(p4) > 0 {
+					summary = fmt.Sprintf("%v", p4[0])
+				}
+			}
+		}
+	case "riding":
+		label = "Federal Riding"
+		summary = extractName(val)
+	case "provriding":
+		label = "Provincial Riding"
+		summary = extractName(val)
+	default:
+		label = key
+	}
+	return label, summary
+}
+
+// extractFromArray extracts a named string field from the first element of an array.
+func extractFromArray(val interface{}, key string) string {
+	arr, ok := val.([]interface{})
+	if !ok || len(arr) == 0 {
+		return ""
+	}
+	m, ok := arr[0].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	if s, ok := m[key].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// extractName extracts the "name" field from a map.
+func extractName(val interface{}) string {
+	m, ok := val.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	if s, ok := m["name"].(string); ok {
+		return s
+	}
+	return ""
 }
 
 // FormatBatchGeocode formats a batch geocode response.

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -129,17 +129,6 @@ func (h *Human) printJSON(val interface{}, prefix string) {
 	}
 }
 
-// isFlat returns true if all values in the map are scalar (not maps or slices).
-func isFlat(m map[string]interface{}) bool {
-	for _, v := range m {
-		switch v.(type) {
-		case map[string]interface{}, []interface{}:
-			return false
-		}
-	}
-	return true
-}
-
 // fieldSummary returns a human-friendly label and summary value for a known field.
 // For unknown fields, it returns the raw key name and an empty summary.
 func fieldSummary(key string, val interface{}) (label, summary string) {

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -59,6 +60,31 @@ func (h *Human) formatResult(r *api.GeocodeResult, num, total int) {
 	}
 	if h.opts.ShowAddressKey && r.StableAddressKey != "" {
 		h.printField("Address Key", r.StableAddressKey)
+	}
+	if r.Fields != nil && len(*r.Fields) > 0 {
+		fmt.Fprintln(h.w)
+		fmt.Fprintf(h.w, "  %s\n", h.style(HeaderStyle, "Fields:"))
+		fieldNames := make([]string, 0, len(*r.Fields))
+		for name := range *r.Fields {
+			fieldNames = append(fieldNames, name)
+		}
+		sort.Strings(fieldNames)
+		for _, name := range fieldNames {
+			val := (*r.Fields)[name]
+			if nested, ok := val.(map[string]interface{}); ok {
+				fmt.Fprintf(h.w, "    %s\n", h.style(LabelStyle, name))
+				subKeys := make([]string, 0, len(nested))
+				for k := range nested {
+					subKeys = append(subKeys, k)
+				}
+				sort.Strings(subKeys)
+				for _, k := range subKeys {
+					fmt.Fprintf(h.w, "      %-18s %v\n", k, nested[k])
+				}
+			} else {
+				h.printField(name, fmt.Sprintf("%v", val))
+			}
+		}
 	}
 	if len(r.Destinations) > 0 {
 		fmt.Fprintln(h.w)

--- a/internal/output/human_test.go
+++ b/internal/output/human_test.go
@@ -190,6 +190,76 @@ func TestHuman_FormatGeocodeStableAddressKey(t *testing.T) {
 	})
 }
 
+func TestHuman_FormatGeocodeWithFields(t *testing.T) {
+	resp := &api.GeocodeResponse{
+		Results: []api.GeocodeResult{
+			{
+				FormattedAddress: "1600 Pennsylvania Ave NW, Washington, DC 20500",
+				Location:         api.Location{Lat: 38.897675, Lng: -77.036547},
+				Accuracy:         1.0,
+				AccuracyType:     "rooftop",
+				Fields: &api.Fields{
+					"timezone": map[string]interface{}{
+						"name":         "America/New_York",
+						"utc_offset":   float64(-5),
+						"observes_dst": true,
+						"abbreviation": "EST",
+					},
+					"congressional_districts": map[string]interface{}{
+						"name": "Congressional District 98",
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	h := NewHuman(&buf, false, Options{})
+
+	err := h.FormatGeocode(resp)
+	if err != nil {
+		t.Fatalf("FormatGeocode() error = %v", err)
+	}
+
+	output := buf.String()
+	wantContains := []string{
+		"Fields:",
+		"timezone",
+		"America/New_York",
+		"congressional_districts",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestHuman_FormatGeocodeWithFields_NoFields(t *testing.T) {
+	resp := &api.GeocodeResponse{
+		Results: []api.GeocodeResult{
+			{
+				FormattedAddress: "1600 Pennsylvania Ave NW, Washington, DC 20500",
+				Location:         api.Location{Lat: 38.897675, Lng: -77.036547},
+				AccuracyType:     "rooftop",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	h := NewHuman(&buf, false, Options{})
+
+	err := h.FormatGeocode(resp)
+	if err != nil {
+		t.Fatalf("FormatGeocode() error = %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "Fields:") {
+		t.Errorf("output should not contain 'Fields:' when no fields requested:\n%s", output)
+	}
+}
+
 func TestHuman_FormatBatchGeocode(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/output/human_test.go
+++ b/internal/output/human_test.go
@@ -205,8 +205,11 @@ func TestHuman_FormatGeocodeWithFields(t *testing.T) {
 						"observes_dst": true,
 						"abbreviation": "EST",
 					},
-					"congressional_districts": map[string]interface{}{
-						"name": "Congressional District 98",
+					"congressional_districts": []interface{}{
+						map[string]interface{}{
+							"name":            "Congressional District 8",
+							"district_number": float64(8),
+						},
 					},
 				},
 			},
@@ -222,11 +225,13 @@ func TestHuman_FormatGeocodeWithFields(t *testing.T) {
 	}
 
 	output := buf.String()
+	// Should have summary labels
 	wantContains := []string{
 		"Fields:",
-		"timezone",
+		"Timezone",
 		"America/New_York",
-		"congressional_districts",
+		"Congressional District",
+		"Congressional District 8",
 	}
 	for _, want := range wantContains {
 		if !strings.Contains(output, want) {

--- a/testdata/distance_km.json
+++ b/testdata/distance_km.json
@@ -1,0 +1,55 @@
+{
+  "origin": {
+    "location": [
+      38.911936,
+      -77.016719
+    ],
+    "geocode": {
+      "address_components": {
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20001",
+        "country": "US"
+      },
+      "formatted_address": "Washington, DC 20001",
+      "location": {
+        "lat": 38.911936,
+        "lng": -77.016719
+      },
+      "accuracy": 1,
+      "accuracy_type": "place",
+      "source": "TIGER/Line® dataset from the US Census Bureau"
+    }
+  },
+  "mode": "driving",
+  "destinations": [
+    {
+      "query": "New York",
+      "location": [
+        40.750422,
+        -73.996328
+      ],
+      "distance_miles": 226.6,
+      "distance_km": 364.7,
+      "duration_seconds": 17061,
+      "geocode": {
+        "address_components": {
+          "city": "New York",
+          "county": "New York County",
+          "state": "NY",
+          "zip": "10001",
+          "country": "US"
+        },
+        "formatted_address": "New York, NY 10001",
+        "location": {
+          "lat": 40.750422,
+          "lng": -73.996328
+        },
+        "accuracy": 1,
+        "accuracy_type": "place",
+        "source": "TIGER/Line® dataset from the US Census Bureau"
+      }
+    }
+  ]
+}

--- a/testdata/distance_multiple.json
+++ b/testdata/distance_multiple.json
@@ -1,0 +1,109 @@
+{
+  "origin": {
+    "location": [
+      38.911936,
+      -77.016719
+    ],
+    "geocode": {
+      "address_components": {
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20001",
+        "country": "US"
+      },
+      "formatted_address": "Washington, DC 20001",
+      "location": {
+        "lat": 38.911936,
+        "lng": -77.016719
+      },
+      "accuracy": 1,
+      "accuracy_type": "place",
+      "source": "TIGER/Line® dataset from the US Census Bureau"
+    }
+  },
+  "mode": "driving",
+  "destinations": [
+    {
+      "query": "Philadelphia",
+      "location": [
+        40.001811,
+        -75.11787
+      ],
+      "distance_miles": 141.8,
+      "distance_km": 228.2,
+      "duration_seconds": 11069,
+      "geocode": {
+        "address_components": {
+          "city": "Philadelphia",
+          "county": "Philadelphia County",
+          "state": "PA",
+          "zip": "19101",
+          "country": "US"
+        },
+        "formatted_address": "Philadelphia, PA 19101",
+        "location": {
+          "lat": 40.001811,
+          "lng": -75.11787
+        },
+        "accuracy": 1,
+        "accuracy_type": "place",
+        "source": "TIGER/Line® dataset from the US Census Bureau"
+      }
+    },
+    {
+      "query": "New York",
+      "location": [
+        40.750422,
+        -73.996328
+      ],
+      "distance_miles": 226.6,
+      "distance_km": 364.7,
+      "duration_seconds": 17061,
+      "geocode": {
+        "address_components": {
+          "city": "New York",
+          "county": "New York County",
+          "state": "NY",
+          "zip": "10001",
+          "country": "US"
+        },
+        "formatted_address": "New York, NY 10001",
+        "location": {
+          "lat": 40.750422,
+          "lng": -73.996328
+        },
+        "accuracy": 1,
+        "accuracy_type": "place",
+        "source": "TIGER/Line® dataset from the US Census Bureau"
+      }
+    },
+    {
+      "query": "Boston",
+      "location": [
+        42.354318,
+        -71.073449
+      ],
+      "distance_miles": 434.4,
+      "distance_km": 699.2,
+      "duration_seconds": 32715,
+      "geocode": {
+        "address_components": {
+          "city": "Boston",
+          "county": "Suffolk County",
+          "state": "MA",
+          "zip": "02106",
+          "country": "US"
+        },
+        "formatted_address": "Boston, MA 02106",
+        "location": {
+          "lat": 42.354318,
+          "lng": -71.073449
+        },
+        "accuracy": 1,
+        "accuracy_type": "place",
+        "source": "TIGER/Line® dataset from the US Census Bureau"
+      }
+    }
+  ]
+}

--- a/testdata/distance_simple.json
+++ b/testdata/distance_simple.json
@@ -1,0 +1,55 @@
+{
+  "origin": {
+    "location": [
+      38.911936,
+      -77.016719
+    ],
+    "geocode": {
+      "address_components": {
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20001",
+        "country": "US"
+      },
+      "formatted_address": "Washington, DC 20001",
+      "location": {
+        "lat": 38.911936,
+        "lng": -77.016719
+      },
+      "accuracy": 1,
+      "accuracy_type": "place",
+      "source": "TIGER/Line® dataset from the US Census Bureau"
+    }
+  },
+  "mode": "driving",
+  "destinations": [
+    {
+      "query": "New York",
+      "location": [
+        40.750422,
+        -73.996328
+      ],
+      "distance_miles": 226.6,
+      "distance_km": 364.7,
+      "duration_seconds": 17061,
+      "geocode": {
+        "address_components": {
+          "city": "New York",
+          "county": "New York County",
+          "state": "NY",
+          "zip": "10001",
+          "country": "US"
+        },
+        "formatted_address": "New York, NY 10001",
+        "location": {
+          "lat": 40.750422,
+          "lng": -73.996328
+        },
+        "accuracy": 1,
+        "accuracy_type": "place",
+        "source": "TIGER/Line® dataset from the US Census Bureau"
+      }
+    }
+  ]
+}

--- a/testdata/geocode_address_key.json
+++ b/testdata/geocode_address_key.json
@@ -1,0 +1,38 @@
+{
+  "input": {
+    "address_components": {
+      "number": "1600",
+      "street": "Pennsylvania",
+      "suffix": "Ave",
+      "postdirectional": "NW",
+      "city": "Washington",
+      "state": "DC",
+      "country": "US"
+    },
+    "formatted_address": "1600 Pennsylvania Ave NW, Washington, DC"
+  },
+  "results": [
+    {
+      "address_components": {
+        "number": "1600",
+        "street": "Pennsylvania",
+        "suffix": "Ave",
+        "postdirectional": "NW",
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20500",
+        "country": "US"
+      },
+      "formatted_address": "1600 Pennsylvania Ave NW, Washington, DC 20500",
+      "location": {
+        "lat": 38.897675,
+        "lng": -77.036547
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Statewide (City of Washington)",
+      "stable_address_key": "gcod_usnqu2qtyk7ac38dlpzanec598p2c"
+    }
+  ]
+}

--- a/testdata/geocode_destinations.json
+++ b/testdata/geocode_destinations.json
@@ -1,0 +1,92 @@
+{
+  "input": {
+    "address_components": {
+      "number": "1600",
+      "street": "Pennsylvania",
+      "suffix": "Ave",
+      "postdirectional": "NW",
+      "city": "Washington",
+      "state": "DC",
+      "country": "US"
+    },
+    "formatted_address": "1600 Pennsylvania Ave NW, Washington, DC"
+  },
+  "results": [
+    {
+      "address_components": {
+        "number": "1600",
+        "street": "Pennsylvania",
+        "suffix": "Ave",
+        "postdirectional": "NW",
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20500",
+        "country": "US"
+      },
+      "formatted_address": "1600 Pennsylvania Ave NW, Washington, DC 20500",
+      "location": {
+        "lat": 38.897675,
+        "lng": -77.036547
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Statewide (City of Washington)",
+      "stable_address_key": "gcod_usnqu2qtyk7ac38dlpzanec598p2c",
+      "destinations": [
+        {
+          "query": "New York",
+          "location": [
+            40.750422,
+            -73.996328
+          ],
+          "distance_miles": 206.2,
+          "distance_km": 331.8,
+          "geocode": {
+            "address_components": {
+              "city": "New York",
+              "county": "New York County",
+              "state": "NY",
+              "zip": "10001",
+              "country": "US"
+            },
+            "formatted_address": "New York, NY 10001",
+            "location": {
+              "lat": 40.750422,
+              "lng": -73.996328
+            },
+            "accuracy": 1,
+            "accuracy_type": "place",
+            "source": "TIGER/Line® dataset from the US Census Bureau"
+          }
+        },
+        {
+          "query": "Boston",
+          "location": [
+            42.354318,
+            -71.073449
+          ],
+          "distance_miles": 393.7,
+          "distance_km": 633.7,
+          "geocode": {
+            "address_components": {
+              "city": "Boston",
+              "county": "Suffolk County",
+              "state": "MA",
+              "zip": "02106",
+              "country": "US"
+            },
+            "formatted_address": "Boston, MA 02106",
+            "location": {
+              "lat": 42.354318,
+              "lng": -71.073449
+            },
+            "accuracy": 1,
+            "accuracy_type": "place",
+            "source": "TIGER/Line® dataset from the US Census Bureau"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/geocode_driving.json
+++ b/testdata/geocode_driving.json
@@ -1,0 +1,67 @@
+{
+  "input": {
+    "address_components": {
+      "number": "1600",
+      "street": "Pennsylvania",
+      "suffix": "Ave",
+      "postdirectional": "NW",
+      "city": "Washington",
+      "state": "DC",
+      "country": "US"
+    },
+    "formatted_address": "1600 Pennsylvania Ave NW, Washington, DC"
+  },
+  "results": [
+    {
+      "address_components": {
+        "number": "1600",
+        "street": "Pennsylvania",
+        "suffix": "Ave",
+        "postdirectional": "NW",
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20500",
+        "country": "US"
+      },
+      "formatted_address": "1600 Pennsylvania Ave NW, Washington, DC 20500",
+      "location": {
+        "lat": 38.897675,
+        "lng": -77.036547
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Statewide (City of Washington)",
+      "stable_address_key": "gcod_usnqu2qtyk7ac38dlpzanec598p2c",
+      "destinations": [
+        {
+          "query": "New York",
+          "location": [
+            40.750422,
+            -73.996328
+          ],
+          "distance_miles": 227.2,
+          "distance_km": 365.7,
+          "duration_seconds": 17302,
+          "geocode": {
+            "address_components": {
+              "city": "New York",
+              "county": "New York County",
+              "state": "NY",
+              "zip": "10001",
+              "country": "US"
+            },
+            "formatted_address": "New York, NY 10001",
+            "location": {
+              "lat": 40.750422,
+              "lng": -73.996328
+            },
+            "accuracy": 1,
+            "accuracy_type": "place",
+            "source": "TIGER/Line® dataset from the US Census Bureau"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/geocode_fields.json
+++ b/testdata/geocode_fields.json
@@ -1,0 +1,339 @@
+{
+  "input": {
+    "address_components": {
+      "number": "30",
+      "street": "Rockefeller",
+      "suffix": "Plz",
+      "city": "New York",
+      "state": "NY",
+      "country": "US"
+    },
+    "formatted_address": "30 Rockefeller Plz, New York, NY"
+  },
+  "results": [
+    {
+      "address_components": {
+        "number": "30",
+        "street": "Rockefeller",
+        "suffix": "Plz",
+        "city": "New York",
+        "county": "New York County",
+        "state": "NY",
+        "zip": "10112",
+        "country": "US"
+      },
+      "formatted_address": "30 Rockefeller Plz, New York, NY 10112",
+      "location": {
+        "lat": 40.758836,
+        "lng": -73.978814
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "City of New York",
+      "stable_address_key": "gcod_usn2qxn8yabv7c9g3v92gmja3mz23",
+      "fields": {
+        "congressional_districts": [
+          {
+            "congress_number": "119th",
+            "congress_years": "2025-2027",
+            "current_legislators": [
+              {
+                "bio": {
+                  "birthday": "1947-06-13",
+                  "first_name": "Jerrold",
+                  "gender": "M",
+                  "last_name": "Nadler",
+                  "party": "Democrat",
+                  "photo_attribution": "Image courtesy of the Member",
+                  "photo_url": "https://www.congress.gov/img/member/n000002_200.jpg"
+                },
+                "contact": {
+                  "address": "2132 Rayburn House Office Building Washington DC 20515-3212",
+                  "contact_form": null,
+                  "phone": "202-225-5635",
+                  "url": "https://nadler.house.gov"
+                },
+                "references": {
+                  "ballotpedia_id": "Jerrold Nadler",
+                  "bioguide_id": "N000002",
+                  "cspan_id": "26159",
+                  "govtrack_id": "400289",
+                  "icpsr_id": "29377",
+                  "lis_id": null,
+                  "opensecrets_id": "N00000939",
+                  "thomas_id": "00850",
+                  "votesmart_id": "26980",
+                  "washington_post_id": null,
+                  "wikipedia_id": "Jerry Nadler"
+                },
+                "seniority": null,
+                "social": {
+                  "facebook": "CongressmanNadler",
+                  "rss_url": "http://nadler.house.gov/rss.xml",
+                  "twitter": "RepJerryNadler",
+                  "youtube": "congressmannadler",
+                  "youtube_id": "UCQKj0qU1e7o2f5ftSh-c9aQ"
+                },
+                "source": "Legislator data collected by the @unitedstates project (https://github.com/unitedstates/)",
+                "type": "representative"
+              },
+              {
+                "bio": {
+                  "birthday": "1950-11-23",
+                  "first_name": "Charles",
+                  "gender": "M",
+                  "last_name": "Schumer",
+                  "party": "Democrat",
+                  "photo_attribution": "Courtesy U.S. Senate Historical Office (http://www.senate.gov/artandhistory/history/common/generic/Photo_Collection_of_the_Senate_Historical_Office.htm)",
+                  "photo_url": "https://www.congress.gov/img/member/s000148_200.jpg"
+                },
+                "contact": {
+                  "address": "322 Hart Senate Office Building Washington DC 20510",
+                  "contact_form": "https://www.schumer.senate.gov/contact/email-chuck",
+                  "phone": "202-224-6542",
+                  "url": "https://www.schumer.senate.gov"
+                },
+                "references": {
+                  "ballotpedia_id": "Chuck Schumer",
+                  "bioguide_id": "S000148",
+                  "cspan_id": "5929",
+                  "govtrack_id": "300087",
+                  "icpsr_id": "14858",
+                  "lis_id": "S270",
+                  "opensecrets_id": "N00001093",
+                  "thomas_id": "01036",
+                  "votesmart_id": "26976",
+                  "washington_post_id": null,
+                  "wikipedia_id": "Chuck Schumer"
+                },
+                "seniority": "senior",
+                "social": {
+                  "facebook": "senschumer",
+                  "rss_url": null,
+                  "twitter": "SenSchumer",
+                  "youtube": "SenatorSchumer",
+                  "youtube_id": "UC-ABttxh8uQv_10qmwGaidw"
+                },
+                "source": "Legislator data collected by the @unitedstates project (https://github.com/unitedstates/)",
+                "type": "senator"
+              },
+              {
+                "bio": {
+                  "birthday": "1966-12-09",
+                  "first_name": "Kirsten",
+                  "gender": "F",
+                  "last_name": "Gillibrand",
+                  "party": "Democrat",
+                  "photo_attribution": "Courtesy U.S. Senate Historical Office (http://www.senate.gov/artandhistory/history/common/generic/Photo_Collection_of_the_Senate_Historical_Office.htm)",
+                  "photo_url": "https://www.congress.gov/img/member/g000555_200.jpg"
+                },
+                "contact": {
+                  "address": "478 Russell Senate Office Building Washington DC 20510",
+                  "contact_form": "https://www.gillibrand.senate.gov/contact/email-me",
+                  "phone": "202-224-4451",
+                  "url": "https://www.gillibrand.senate.gov"
+                },
+                "references": {
+                  "ballotpedia_id": "Kirsten Gillibrand",
+                  "bioguide_id": "G000555",
+                  "cspan_id": "1022862",
+                  "govtrack_id": "412223",
+                  "icpsr_id": "20735",
+                  "lis_id": "S331",
+                  "opensecrets_id": "N00027658",
+                  "thomas_id": "01866",
+                  "votesmart_id": "65147",
+                  "washington_post_id": null,
+                  "wikipedia_id": "Kirsten Gillibrand"
+                },
+                "seniority": "junior",
+                "social": {
+                  "facebook": "SenKirstenGillibrand",
+                  "rss_url": "http://www.gillibrand.senate.gov/rss/",
+                  "twitter": "GillibrandNY",
+                  "youtube": "KirstenEGillibrand",
+                  "youtube_id": "UCVEloQogVsmnkd5vxJInmYg"
+                },
+                "source": "Legislator data collected by the @unitedstates project (https://github.com/unitedstates/)",
+                "type": "senator"
+              }
+            ],
+            "district_number": 12,
+            "name": "Congressional District 12",
+            "ocd_id": "ocd-division/country:us/state:ny/cd:12",
+            "proportion": 1
+          }
+        ],
+        "timezone": {
+          "abbreviation": "EST",
+          "name": "America/New_York",
+          "observes_dst": true,
+          "source": "© OpenStreetMap contributors",
+          "utc_offset": -5
+        }
+      }
+    },
+    {
+      "address_components": {
+        "number": "30",
+        "street": "Rockefeller",
+        "suffix": "Plz",
+        "city": "New York",
+        "county": "New York County",
+        "state": "NY",
+        "zip": "10112",
+        "country": "US"
+      },
+      "formatted_address": "30 Rockefeller Plz, New York, NY 10112",
+      "location": {
+        "lat": 40.759033,
+        "lng": -73.978287
+      },
+      "accuracy": 1,
+      "accuracy_type": "range_interpolation",
+      "source": "TIGER/Line® from the US Census Bureau",
+      "stable_address_key": "gcod_usnrxk3h7zyvax22hr3383csnkh6c",
+      "fields": {
+        "congressional_districts": [
+          {
+            "congress_number": "119th",
+            "congress_years": "2025-2027",
+            "current_legislators": [
+              {
+                "bio": {
+                  "birthday": "1947-06-13",
+                  "first_name": "Jerrold",
+                  "gender": "M",
+                  "last_name": "Nadler",
+                  "party": "Democrat",
+                  "photo_attribution": "Image courtesy of the Member",
+                  "photo_url": "https://www.congress.gov/img/member/n000002_200.jpg"
+                },
+                "contact": {
+                  "address": "2132 Rayburn House Office Building Washington DC 20515-3212",
+                  "contact_form": null,
+                  "phone": "202-225-5635",
+                  "url": "https://nadler.house.gov"
+                },
+                "references": {
+                  "ballotpedia_id": "Jerrold Nadler",
+                  "bioguide_id": "N000002",
+                  "cspan_id": "26159",
+                  "govtrack_id": "400289",
+                  "icpsr_id": "29377",
+                  "lis_id": null,
+                  "opensecrets_id": "N00000939",
+                  "thomas_id": "00850",
+                  "votesmart_id": "26980",
+                  "washington_post_id": null,
+                  "wikipedia_id": "Jerry Nadler"
+                },
+                "seniority": null,
+                "social": {
+                  "facebook": "CongressmanNadler",
+                  "rss_url": "http://nadler.house.gov/rss.xml",
+                  "twitter": "RepJerryNadler",
+                  "youtube": "congressmannadler",
+                  "youtube_id": "UCQKj0qU1e7o2f5ftSh-c9aQ"
+                },
+                "source": "Legislator data collected by the @unitedstates project (https://github.com/unitedstates/)",
+                "type": "representative"
+              },
+              {
+                "bio": {
+                  "birthday": "1950-11-23",
+                  "first_name": "Charles",
+                  "gender": "M",
+                  "last_name": "Schumer",
+                  "party": "Democrat",
+                  "photo_attribution": "Courtesy U.S. Senate Historical Office (http://www.senate.gov/artandhistory/history/common/generic/Photo_Collection_of_the_Senate_Historical_Office.htm)",
+                  "photo_url": "https://www.congress.gov/img/member/s000148_200.jpg"
+                },
+                "contact": {
+                  "address": "322 Hart Senate Office Building Washington DC 20510",
+                  "contact_form": "https://www.schumer.senate.gov/contact/email-chuck",
+                  "phone": "202-224-6542",
+                  "url": "https://www.schumer.senate.gov"
+                },
+                "references": {
+                  "ballotpedia_id": "Chuck Schumer",
+                  "bioguide_id": "S000148",
+                  "cspan_id": "5929",
+                  "govtrack_id": "300087",
+                  "icpsr_id": "14858",
+                  "lis_id": "S270",
+                  "opensecrets_id": "N00001093",
+                  "thomas_id": "01036",
+                  "votesmart_id": "26976",
+                  "washington_post_id": null,
+                  "wikipedia_id": "Chuck Schumer"
+                },
+                "seniority": "senior",
+                "social": {
+                  "facebook": "senschumer",
+                  "rss_url": null,
+                  "twitter": "SenSchumer",
+                  "youtube": "SenatorSchumer",
+                  "youtube_id": "UC-ABttxh8uQv_10qmwGaidw"
+                },
+                "source": "Legislator data collected by the @unitedstates project (https://github.com/unitedstates/)",
+                "type": "senator"
+              },
+              {
+                "bio": {
+                  "birthday": "1966-12-09",
+                  "first_name": "Kirsten",
+                  "gender": "F",
+                  "last_name": "Gillibrand",
+                  "party": "Democrat",
+                  "photo_attribution": "Courtesy U.S. Senate Historical Office (http://www.senate.gov/artandhistory/history/common/generic/Photo_Collection_of_the_Senate_Historical_Office.htm)",
+                  "photo_url": "https://www.congress.gov/img/member/g000555_200.jpg"
+                },
+                "contact": {
+                  "address": "478 Russell Senate Office Building Washington DC 20510",
+                  "contact_form": "https://www.gillibrand.senate.gov/contact/email-me",
+                  "phone": "202-224-4451",
+                  "url": "https://www.gillibrand.senate.gov"
+                },
+                "references": {
+                  "ballotpedia_id": "Kirsten Gillibrand",
+                  "bioguide_id": "G000555",
+                  "cspan_id": "1022862",
+                  "govtrack_id": "412223",
+                  "icpsr_id": "20735",
+                  "lis_id": "S331",
+                  "opensecrets_id": "N00027658",
+                  "thomas_id": "01866",
+                  "votesmart_id": "65147",
+                  "washington_post_id": null,
+                  "wikipedia_id": "Kirsten Gillibrand"
+                },
+                "seniority": "junior",
+                "social": {
+                  "facebook": "SenKirstenGillibrand",
+                  "rss_url": "http://www.gillibrand.senate.gov/rss/",
+                  "twitter": "GillibrandNY",
+                  "youtube": "KirstenEGillibrand",
+                  "youtube_id": "UCVEloQogVsmnkd5vxJInmYg"
+                },
+                "source": "Legislator data collected by the @unitedstates project (https://github.com/unitedstates/)",
+                "type": "senator"
+              }
+            ],
+            "district_number": 12,
+            "name": "Congressional District 12",
+            "ocd_id": "ocd-division/country:us/state:ny/cd:12",
+            "proportion": 1
+          }
+        ],
+        "timezone": {
+          "abbreviation": "EST",
+          "name": "America/New_York",
+          "observes_dst": true,
+          "source": "© OpenStreetMap contributors",
+          "utc_offset": -5
+        }
+      }
+    }
+  ]
+}

--- a/testdata/geocode_simple.json
+++ b/testdata/geocode_simple.json
@@ -1,0 +1,38 @@
+{
+  "input": {
+    "address_components": {
+      "number": "1600",
+      "street": "Pennsylvania",
+      "suffix": "Ave",
+      "postdirectional": "NW",
+      "city": "Washington",
+      "state": "DC",
+      "country": "US"
+    },
+    "formatted_address": "1600 Pennsylvania Ave NW, Washington, DC"
+  },
+  "results": [
+    {
+      "address_components": {
+        "number": "1600",
+        "street": "Pennsylvania",
+        "suffix": "Ave",
+        "postdirectional": "NW",
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20500",
+        "country": "US"
+      },
+      "formatted_address": "1600 Pennsylvania Ave NW, Washington, DC 20500",
+      "location": {
+        "lat": 38.897675,
+        "lng": -77.036547
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Statewide (City of Washington)",
+      "stable_address_key": "gcod_usnqu2qtyk7ac38dlpzanec598p2c"
+    }
+  ]
+}

--- a/testdata/reverse_simple.json
+++ b/testdata/reverse_simple.json
@@ -1,0 +1,137 @@
+{
+  "input": null,
+  "results": [
+    {
+      "address_components": {
+        "number": "1600",
+        "street": "Pennsylvania",
+        "suffix": "Ave",
+        "postdirectional": "NW",
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20500",
+        "country": "US"
+      },
+      "formatted_address": "1600 Pennsylvania Ave NW, Washington, DC 20500",
+      "location": {
+        "lat": 38.897675,
+        "lng": -77.036547
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Statewide (City of Washington)",
+      "stable_address_key": "gcod_usnqu2qtyk7ac38dlpzanec598p2c"
+    },
+    {
+      "address_components": {
+        "number": "1500",
+        "street": "Pennsylvania",
+        "suffix": "Ave",
+        "postdirectional": "NW",
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20229",
+        "country": "US"
+      },
+      "formatted_address": "1500 Pennsylvania Ave NW, Washington, DC 20229",
+      "location": {
+        "lat": 38.89815,
+        "lng": -77.034336
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Statewide (City of Washington)",
+      "stable_address_key": "gcod_usncnq6krcdc49ue8rye8fb3be2d4"
+    },
+    {
+      "address_components": {
+        "number": "700",
+        "street": "Jackson",
+        "suffix": "Pl",
+        "postdirectional": "NW",
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20006",
+        "country": "US"
+      },
+      "formatted_address": "700 Jackson Pl NW, Washington, DC 20006",
+      "location": {
+        "lat": 38.898976,
+        "lng": -77.038219
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Statewide (City of Washington)",
+      "stable_address_key": "gcod_usnseh6yc5ufb6c5marenzsbe9rx9"
+    },
+    {
+      "address_components": {
+        "number": "704",
+        "street": "Jackson",
+        "suffix": "Pl",
+        "postdirectional": "NW",
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20006",
+        "country": "US"
+      },
+      "formatted_address": "704 Jackson Pl NW, Washington, DC 20006",
+      "location": {
+        "lat": 38.899055,
+        "lng": -77.038221
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Statewide (City of Washington)",
+      "stable_address_key": "gcod_usnseh6yc5ufb6c5vmz4rvnzlvnc9"
+    },
+    {
+      "address_components": {
+        "number": "708",
+        "street": "Jackson",
+        "suffix": "Pl",
+        "postdirectional": "NW",
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20006",
+        "country": "US"
+      },
+      "formatted_address": "708 Jackson Pl NW, Washington, DC 20006",
+      "location": {
+        "lat": 38.899132,
+        "lng": -77.038211
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Statewide (City of Washington)",
+      "stable_address_key": "gcod_usnseh6yc5ufb6c5waug5c7d3jdx2"
+    },
+    {
+      "address_components": {
+        "number": "712",
+        "street": "Jackson",
+        "suffix": "Pl",
+        "postdirectional": "NW",
+        "city": "Washington",
+        "county": "District of Columbia",
+        "state": "DC",
+        "zip": "20006",
+        "country": "US"
+      },
+      "formatted_address": "712 Jackson Pl NW, Washington, DC 20006",
+      "location": {
+        "lat": 38.899207,
+        "lng": -77.038217
+      },
+      "accuracy": 1,
+      "accuracy_type": "rooftop",
+      "source": "Statewide (City of Washington)",
+      "stable_address_key": "gcod_usnseh6yc5ufb6c5vfzm46uzmuky7"
+    }
+  ]
+}

--- a/testdata/reverse_skip_fields.json
+++ b/testdata/reverse_skip_fields.json
@@ -1,0 +1,155 @@
+{
+  "input": null,
+  "results": [
+    {
+      "formatted_address": "",
+      "location": {
+        "lat": 40.7588,
+        "lng": -73.9788
+      },
+      "accuracy": 0,
+      "accuracy_type": "coordinate",
+      "fields": {
+        "congressional_districts": [
+          {
+            "congress_number": "119th",
+            "congress_years": "2025-2027",
+            "current_legislators": [
+              {
+                "bio": {
+                  "birthday": "1947-06-13",
+                  "first_name": "Jerrold",
+                  "gender": "M",
+                  "last_name": "Nadler",
+                  "party": "Democrat",
+                  "photo_attribution": "Image courtesy of the Member",
+                  "photo_url": "https://www.congress.gov/img/member/n000002_200.jpg"
+                },
+                "contact": {
+                  "address": "2132 Rayburn House Office Building Washington DC 20515-3212",
+                  "contact_form": null,
+                  "phone": "202-225-5635",
+                  "url": "https://nadler.house.gov"
+                },
+                "references": {
+                  "ballotpedia_id": "Jerrold Nadler",
+                  "bioguide_id": "N000002",
+                  "cspan_id": "26159",
+                  "govtrack_id": "400289",
+                  "icpsr_id": "29377",
+                  "lis_id": null,
+                  "opensecrets_id": "N00000939",
+                  "thomas_id": "00850",
+                  "votesmart_id": "26980",
+                  "washington_post_id": null,
+                  "wikipedia_id": "Jerry Nadler"
+                },
+                "seniority": null,
+                "social": {
+                  "facebook": "CongressmanNadler",
+                  "rss_url": "http://nadler.house.gov/rss.xml",
+                  "twitter": "RepJerryNadler",
+                  "youtube": "congressmannadler",
+                  "youtube_id": "UCQKj0qU1e7o2f5ftSh-c9aQ"
+                },
+                "source": "Legislator data collected by the @unitedstates project (https://github.com/unitedstates/)",
+                "type": "representative"
+              },
+              {
+                "bio": {
+                  "birthday": "1950-11-23",
+                  "first_name": "Charles",
+                  "gender": "M",
+                  "last_name": "Schumer",
+                  "party": "Democrat",
+                  "photo_attribution": "Courtesy U.S. Senate Historical Office (http://www.senate.gov/artandhistory/history/common/generic/Photo_Collection_of_the_Senate_Historical_Office.htm)",
+                  "photo_url": "https://www.congress.gov/img/member/s000148_200.jpg"
+                },
+                "contact": {
+                  "address": "322 Hart Senate Office Building Washington DC 20510",
+                  "contact_form": "https://www.schumer.senate.gov/contact/email-chuck",
+                  "phone": "202-224-6542",
+                  "url": "https://www.schumer.senate.gov"
+                },
+                "references": {
+                  "ballotpedia_id": "Chuck Schumer",
+                  "bioguide_id": "S000148",
+                  "cspan_id": "5929",
+                  "govtrack_id": "300087",
+                  "icpsr_id": "14858",
+                  "lis_id": "S270",
+                  "opensecrets_id": "N00001093",
+                  "thomas_id": "01036",
+                  "votesmart_id": "26976",
+                  "washington_post_id": null,
+                  "wikipedia_id": "Chuck Schumer"
+                },
+                "seniority": "senior",
+                "social": {
+                  "facebook": "senschumer",
+                  "rss_url": null,
+                  "twitter": "SenSchumer",
+                  "youtube": "SenatorSchumer",
+                  "youtube_id": "UC-ABttxh8uQv_10qmwGaidw"
+                },
+                "source": "Legislator data collected by the @unitedstates project (https://github.com/unitedstates/)",
+                "type": "senator"
+              },
+              {
+                "bio": {
+                  "birthday": "1966-12-09",
+                  "first_name": "Kirsten",
+                  "gender": "F",
+                  "last_name": "Gillibrand",
+                  "party": "Democrat",
+                  "photo_attribution": "Courtesy U.S. Senate Historical Office (http://www.senate.gov/artandhistory/history/common/generic/Photo_Collection_of_the_Senate_Historical_Office.htm)",
+                  "photo_url": "https://www.congress.gov/img/member/g000555_200.jpg"
+                },
+                "contact": {
+                  "address": "478 Russell Senate Office Building Washington DC 20510",
+                  "contact_form": "https://www.gillibrand.senate.gov/contact/email-me",
+                  "phone": "202-224-4451",
+                  "url": "https://www.gillibrand.senate.gov"
+                },
+                "references": {
+                  "ballotpedia_id": "Kirsten Gillibrand",
+                  "bioguide_id": "G000555",
+                  "cspan_id": "1022862",
+                  "govtrack_id": "412223",
+                  "icpsr_id": "20735",
+                  "lis_id": "S331",
+                  "opensecrets_id": "N00027658",
+                  "thomas_id": "01866",
+                  "votesmart_id": "65147",
+                  "washington_post_id": null,
+                  "wikipedia_id": "Kirsten Gillibrand"
+                },
+                "seniority": "junior",
+                "social": {
+                  "facebook": "SenKirstenGillibrand",
+                  "rss_url": "http://www.gillibrand.senate.gov/rss/",
+                  "twitter": "GillibrandNY",
+                  "youtube": "KirstenEGillibrand",
+                  "youtube_id": "UCVEloQogVsmnkd5vxJInmYg"
+                },
+                "source": "Legislator data collected by the @unitedstates project (https://github.com/unitedstates/)",
+                "type": "senator"
+              }
+            ],
+            "district_number": 12,
+            "name": "Congressional District 12",
+            "ocd_id": "ocd-division/country:us/state:ny/cd:12",
+            "proportion": 1
+          }
+        ],
+        "timezone": {
+          "abbreviation": "EST",
+          "name": "America/New_York",
+          "observes_dst": true,
+          "source": "© OpenStreetMap contributors",
+          "utc_offset": -5
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION

Closes [ENG-661](https://linear.app/geocodioteam/issue/ENG-661/docs-should-not-use-dc-as-an-example-for-cd-append-as-it-doesnt-have-a)
Closes [ENG-657](https://linear.app/geocodioteam/issue/ENG-657/display-preview-of-appended-field-data-in-default-text-output#comment-6b207300)
Closes [ENG-662](https://linear.app/geocodioteam/issue/ENG-662/distance-and-distance-matrix-commands-missing-country-flag#comment-131ebdc9)
Closes [ENG-659](https://linear.app/geocodioteam/issue/ENG-659/units-km-flag-has-no-effect-on-text-output)
Closes [ENG-655](https://linear.app/geocodioteam/issue/ENG-655/the-destinations-flag-in-geocodio-cli-v200-splits-values-on-commas)
  1. Add field output display in human and agent formatters
  2. Units display respecting --units km and distance-units as correct 
  3. Destination comma-splitting fix
  4. Distance --country flag for Canadian addresses
  5. README example updates
  6. Integration tests