### PR TITLE
Add Mexico support to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ geocodio geocode "1600 Pennsylvania Ave NW, Washington DC" --json
 | `--batch` | `-b` | File containing addresses (one per line) |
 | `--fields` | `-f` | Data append fields (comma-separated) |
 | `--limit` | `-l` | Maximum number of results per address |
-| `--country` | `-c` | Country hint (e.g. `USA`, `Canada`, `United Kingdom`) |
+| `--country` | `-c` | Country hint (e.g. `USA`, `Canada`, `Mexico`, `United Kingdom`) |
 | `--destinations` | `-d` | Destination addresses or coordinates for distance calculation (repeatable) |
 | `--distance-mode` | `-m` | Distance mode: `driving` or `straightline` |
 | `--distance-units` | `-u` | Distance units: `miles` or `km` |
@@ -241,7 +241,7 @@ geocodio distance "Washington DC" "New York" --mode driving --units km
 |------|-------|---------|-------------|
 | `--mode` | `-m` | `driving` | Routing mode: `driving` or `straightline` |
 | `--units` | `-u` | `miles` | Distance units: `miles` or `km` |
-| `--country` | `-c` | | Country to append to addresses: `USA`, `Canada`, or `United Kingdom` |
+| `--country` | `-c` | | Country to append to addresses: `USA`, `Canada`, `Mexico`, or `United Kingdom` |
 
 > [!TIP]
 > Use `straightline` mode for quick "as the crow flies" distances when you don't need actual driving routes.

--- a/internal/cli/destinations_test.go
+++ b/internal/cli/destinations_test.go
@@ -30,6 +30,18 @@ func TestAppendCountry(t *testing.T) {
 			want:    "Springfield IL, USA",
 		},
 		{
+			name:    "appends Mexico",
+			address: "Avenida Juárez, Guadalajara",
+			country: "Mexico",
+			want:    "Avenida Juárez, Guadalajara, Mexico",
+		},
+		{
+			name:    "appends Mexico case-insensitive",
+			address: "Avenida Juárez, Guadalajara",
+			country: "mexico",
+			want:    "Avenida Juárez, Guadalajara, Mexico",
+		},
+		{
 			name:    "appends United Kingdom",
 			address: "10 Downing St, London",
 			country: "United Kingdom",

--- a/internal/cli/distance.go
+++ b/internal/cli/distance.go
@@ -12,7 +12,7 @@ import (
 )
 
 // appendCountry appends the country to an address if it's not already present.
-// Only accepts "USA", "Canada", or "United Kingdom" (case-insensitive). Other values are ignored.
+// Only accepts "USA", "Canada", "Mexico", or "United Kingdom" (case-insensitive). Other values are ignored.
 func appendCountry(address, country string) string {
 	if country == "" {
 		return address
@@ -34,6 +34,8 @@ func normalizeCountry(country string) string {
 		return "USA"
 	case "canada":
 		return "Canada"
+	case "mexico":
+		return "Mexico"
 	case "united kingdom":
 		return "United Kingdom"
 	default:
@@ -74,7 +76,7 @@ func distanceCmd() *cli.Command {
 			&cli.StringFlag{
 				Name:    "country",
 				Aliases: []string{"c"},
-				Usage:   "Country to append to addresses (e.g. USA, Canada, United Kingdom)",
+				Usage:   "Country to append to addresses (e.g. USA, Canada, Mexico, United Kingdom)",
 			},
 		},
 		Action: distanceAction,
@@ -94,7 +96,7 @@ func distanceAction(ctx context.Context, cmd *cli.Command) error {
 	args := cmd.Args().Slice()
 	country := cmd.String("country")
 	if country != "" && normalizeCountry(country) == "" {
-		fmt.Fprintf(app.stderr, "Warning: %q is not a valid country. Accepted values are USA, Canada, or United Kingdom. Flag will be ignored.\n", country)
+		fmt.Fprintf(app.stderr, "Warning: %q is not a valid country. Accepted values are USA, Canada, Mexico, or United Kingdom. Flag will be ignored.\n", country)
 	}
 	origin := appendCountry(args[0], country)
 	destinations := appendCountryToAll(args[1:], country)
@@ -139,7 +141,7 @@ func distanceMatrixCmd() *cli.Command {
 			&cli.StringFlag{
 				Name:    "country",
 				Aliases: []string{"c"},
-				Usage:   "Country to append to addresses (e.g. USA, Canada, United Kingdom)",
+				Usage:   "Country to append to addresses (e.g. USA, Canada, Mexico, United Kingdom)",
 			},
 		},
 		Action: distanceMatrixAction,
@@ -172,7 +174,7 @@ func distanceMatrixAction(ctx context.Context, cmd *cli.Command) error {
 
 	country := cmd.String("country")
 	if country != "" && normalizeCountry(country) == "" {
-		fmt.Fprintf(app.stderr, "Warning: %q is not a valid country. Accepted values are USA, Canada, or United Kingdom. Flag will be ignored.\n", country)
+		fmt.Fprintf(app.stderr, "Warning: %q is not a valid country. Accepted values are USA, Canada, Mexico, or United Kingdom. Flag will be ignored.\n", country)
 	}
 	origins = appendCountryToAll(origins, country)
 	destinations = appendCountryToAll(destinations, country)

--- a/internal/cli/geocode.go
+++ b/internal/cli/geocode.go
@@ -38,7 +38,7 @@ func geocodeCmd() *cli.Command {
 			&cli.StringFlag{
 				Name:    "country",
 				Aliases: []string{"c"},
-				Usage:   "Country hint (e.g. USA, Canada, United Kingdom)",
+				Usage:   "Country hint (e.g. USA, Canada, Mexico, United Kingdom)",
 			},
 			&cli.BoolFlag{
 				Name:  "show-address-key",

--- a/skills/geocodio/SKILL.md
+++ b/skills/geocodio/SKILL.md
@@ -32,7 +32,7 @@ geocodio geocode "1600 Pennsylvania Ave NW, Washington DC" --fields timezone,cd
 # Limit results
 geocodio geocode "1600 Pennsylvania Ave NW, Washington DC" --limit 1
 
-# Country hint (e.g. USA, Canada, United Kingdom)
+# Country hint (e.g. USA, Canada, Mexico, United Kingdom)
 geocodio geocode "Ottawa, Ontario" --country Canada
 
 # UK address with UK-specific data appends


### PR DESCRIPTION
Stacked on top of #5 (UK support). Adds Mexico as a fourth accepted `--country` value.

Mexico is simpler than the UK addition: it's **not access-gated** (only `GB` is) and has **no country-specific field appends**, so this is purely the country flag + docs + tests.

Closes ENG-1113

## Changes
- `distance --country` (`normalizeCountry`): accepts `mexico` (case-insensitive) → appends `"Mexico"`. Both `distance` and `distance-matrix` warning strings and flag help updated.
- `geocode --country` usage text: now lists Mexico.
- README + bundled skill: Mexico added to the `--country` rows/hints.
- Tests: Mexico cases in `TestAppendCountry`.

## Tests
`gofmt` clean · `go build ./...` · `go test -race ./...` all pass.

> Note: review/merge #5 first — this PR is stacked on it.