### PR TITLE
Add match_type, address_lines, and formatted_street to geocode results

### DIFF
--- a/internal/api/testdata/geocode_full_response.json
+++ b/internal/api/testdata/geocode_full_response.json
@@ -1,0 +1,280 @@
+{
+    "results": [
+        {
+            "stable_address_key": "gcod_usn222gxcazcmuj4eeyt5stezyq7b-kywxxr77v9db3",
+            "address_components": {
+                "number": "996C",
+                "street": "East",
+                "suffix": "St",
+                "unit_type": "Apt",
+                "unit_number": "10",
+                "formatted_street": "East St",
+                "city": "Walpole",
+                "county": "Norfolk County",
+                "state_province": "MA",
+                "postal_code": "02081",
+                "country": "US"
+            },
+            "address_lines": [
+                "996C East St",
+                "Apt 10",
+                "Walpole, MA 02081"
+            ],
+            "formatted_address": "996C East St, Apt 10, Walpole, MA 02081",
+            "location": {
+                "lat": 42.146821,
+                "lng": -71.254055
+            },
+            "accuracy": 1,
+            "accuracy_type": "rooftop",
+            "match_type": "unit",
+            "source": "Office of Geographic Information (MassGIS), Commonwealth of Massachusetts, MassIT",
+            "fields": {
+                "census": {
+                    "2025": {
+                        "census_year": 2025,
+                        "state_fips": "25",
+                        "county_fips": "25021",
+                        "tract_code": "411302",
+                        "block_code": "2002",
+                        "block_group": "2",
+                        "full_fips": "250214113022002",
+                        "place": {
+                            "name": "Walpole",
+                            "fips": "2572460"
+                        },
+                        "metro_micro_statistical_area": {
+                            "name": "Boston-Cambridge-Newton, MA-NH",
+                            "area_code": "14460",
+                            "type": "metropolitan"
+                        },
+                        "combined_statistical_area": {
+                            "name": "Boston-Worcester-Providence, MA-RI-NH",
+                            "area_code": "148"
+                        },
+                        "metropolitan_division": {
+                            "name": "Boston, MA",
+                            "area_code": "14454"
+                        },
+                        "county_subdivision": {
+                            "name": "Walpole",
+                            "fips": "72495",
+                            "fips_class": {
+                                "class_code": "T1",
+                                "description": "An active county subdivision that is not coextensive with an incorporated place"
+                            }
+                        },
+                        "source": "US Census Bureau"
+                    }
+                }
+            }
+        },
+        {
+            "stable_address_key": "gcod_usn222gxcazcmuj4eeyt5stezyq7b",
+            "address_components": {
+                "number": "996C",
+                "street": "East",
+                "suffix": "St",
+                "unit_type": "Apt",
+                "unit_number": "10",
+                "formatted_street": "East St",
+                "city": "Walpole",
+                "county": "Norfolk County",
+                "state_province": "MA",
+                "postal_code": "02081",
+                "country": "US"
+            },
+            "address_lines": [
+                "996C East St",
+                "Apt 10",
+                "Walpole, MA 02081"
+            ],
+            "formatted_address": "996C East St, Apt 10, Walpole, MA 02081",
+            "location": {
+                "lat": 42.146821,
+                "lng": -71.254055
+            },
+            "accuracy": 1,
+            "accuracy_type": "rooftop",
+            "match_type": "building_centroid",
+            "source": "Office of Geographic Information (MassGIS), Commonwealth of Massachusetts, MassIT",
+            "fields": {
+                "census": {
+                    "2025": {
+                        "census_year": 2025,
+                        "state_fips": "25",
+                        "county_fips": "25021",
+                        "tract_code": "411302",
+                        "block_code": "2002",
+                        "block_group": "2",
+                        "full_fips": "250214113022002",
+                        "place": {
+                            "name": "Walpole",
+                            "fips": "2572460"
+                        },
+                        "metro_micro_statistical_area": {
+                            "name": "Boston-Cambridge-Newton, MA-NH",
+                            "area_code": "14460",
+                            "type": "metropolitan"
+                        },
+                        "combined_statistical_area": {
+                            "name": "Boston-Worcester-Providence, MA-RI-NH",
+                            "area_code": "148"
+                        },
+                        "metropolitan_division": {
+                            "name": "Boston, MA",
+                            "area_code": "14454"
+                        },
+                        "county_subdivision": {
+                            "name": "Walpole",
+                            "fips": "72495",
+                            "fips_class": {
+                                "class_code": "T1",
+                                "description": "An active county subdivision that is not coextensive with an incorporated place"
+                            }
+                        },
+                        "source": "US Census Bureau"
+                    }
+                }
+            }
+        },
+        {
+            "stable_address_key": "gcod_usn222gxcazcmuj48b8kekvjucpyc-6tvssndu3n287",
+            "address_components": {
+                "number": "996",
+                "street": "East",
+                "suffix": "St",
+                "unit_type": "Apt",
+                "unit_number": "10",
+                "formatted_street": "East St",
+                "city": "Walpole",
+                "county": "Norfolk County",
+                "state_province": "MA",
+                "postal_code": "02081",
+                "country": "US"
+            },
+            "address_lines": [
+                "996 East St",
+                "Apt 10",
+                "Walpole, MA 02081"
+            ],
+            "formatted_address": "996 East St, Apt 10, Walpole, MA 02081",
+            "location": {
+                "lat": 42.146821,
+                "lng": -71.254055
+            },
+            "accuracy": 1,
+            "accuracy_type": "rooftop",
+            "match_type": "unit",
+            "source": "Office of Geographic Information (MassGIS), Commonwealth of Massachusetts, MassIT",
+            "fields": {
+                "census": {
+                    "2025": {
+                        "census_year": 2025,
+                        "state_fips": "25",
+                        "county_fips": "25021",
+                        "tract_code": "411302",
+                        "block_code": "2002",
+                        "block_group": "2",
+                        "full_fips": "250214113022002",
+                        "place": {
+                            "name": "Walpole",
+                            "fips": "2572460"
+                        },
+                        "metro_micro_statistical_area": {
+                            "name": "Boston-Cambridge-Newton, MA-NH",
+                            "area_code": "14460",
+                            "type": "metropolitan"
+                        },
+                        "combined_statistical_area": {
+                            "name": "Boston-Worcester-Providence, MA-RI-NH",
+                            "area_code": "148"
+                        },
+                        "metropolitan_division": {
+                            "name": "Boston, MA",
+                            "area_code": "14454"
+                        },
+                        "county_subdivision": {
+                            "name": "Walpole",
+                            "fips": "72495",
+                            "fips_class": {
+                                "class_code": "T1",
+                                "description": "An active county subdivision that is not coextensive with an incorporated place"
+                            }
+                        },
+                        "source": "US Census Bureau"
+                    }
+                }
+            }
+        },
+        {
+            "stable_address_key": "gcod_usn222gxcazcmuj48b8kekvjucpyc",
+            "address_components": {
+                "number": "996",
+                "street": "East",
+                "suffix": "St",
+                "unit_type": "Apt",
+                "unit_number": "10",
+                "formatted_street": "East St",
+                "city": "Walpole",
+                "county": "Norfolk County",
+                "state_province": "MA",
+                "postal_code": "02081",
+                "country": "US"
+            },
+            "address_lines": [
+                "996 East St",
+                "Apt 10",
+                "Walpole, MA 02081"
+            ],
+            "formatted_address": "996 East St, Apt 10, Walpole, MA 02081",
+            "location": {
+                "lat": 42.146821,
+                "lng": -71.254055
+            },
+            "accuracy": 1,
+            "accuracy_type": "rooftop",
+            "match_type": "building_centroid",
+            "source": "Office of Geographic Information (MassGIS), Commonwealth of Massachusetts, MassIT",
+            "fields": {
+                "census": {
+                    "2025": {
+                        "census_year": 2025,
+                        "state_fips": "25",
+                        "county_fips": "25021",
+                        "tract_code": "411302",
+                        "block_code": "2002",
+                        "block_group": "2",
+                        "full_fips": "250214113022002",
+                        "place": {
+                            "name": "Walpole",
+                            "fips": "2572460"
+                        },
+                        "metro_micro_statistical_area": {
+                            "name": "Boston-Cambridge-Newton, MA-NH",
+                            "area_code": "14460",
+                            "type": "metropolitan"
+                        },
+                        "combined_statistical_area": {
+                            "name": "Boston-Worcester-Providence, MA-RI-NH",
+                            "area_code": "148"
+                        },
+                        "metropolitan_division": {
+                            "name": "Boston, MA",
+                            "area_code": "14454"
+                        },
+                        "county_subdivision": {
+                            "name": "Walpole",
+                            "fips": "72495",
+                            "fips_class": {
+                                "class_code": "T1",
+                                "description": "An active county subdivision that is not coextensive with an incorporated place"
+                            }
+                        },
+                        "source": "US Census Bureau"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -41,6 +41,7 @@ type AddressComponents struct {
 	Postdirectional string `json:"postdirectional,omitempty"`
 	UnitType        string `json:"unit_type,omitempty"`
 	UnitNumber      string `json:"unit_number,omitempty"`
+	FormattedStreet string `json:"formatted_street,omitempty"`
 	City            string `json:"city,omitempty"`
 	County          string `json:"county,omitempty"`
 	StateProvince   string `json:"state_province,omitempty"`
@@ -51,10 +52,12 @@ type AddressComponents struct {
 // GeocodeResult represents a single geocoding result.
 type GeocodeResult struct {
 	AddressComponents *AddressComponents    `json:"address_components,omitempty"`
+	AddressLines      []string              `json:"address_lines,omitempty"`
 	FormattedAddress  string                `json:"formatted_address"`
 	Location          Location              `json:"location"`
 	Accuracy          float64               `json:"accuracy"`
 	AccuracyType      string                `json:"accuracy_type"`
+	MatchType         string                `json:"match_type,omitempty"`
 	Source            string                `json:"source,omitempty"`
 	StableAddressKey  string                `json:"stable_address_key,omitempty"`
 	Fields            *Fields               `json:"fields,omitempty"`

--- a/internal/api/types_roundtrip_test.go
+++ b/internal/api/types_roundtrip_test.go
@@ -1,0 +1,102 @@
+package api_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/geocodio/geocodio-cli/internal/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeocodeResponseRoundTripsAllAPIFields guards against response fields
+// silently disappearing from CLI output. The CLI decodes API responses into
+// typed structs and re-encodes them for display, so any response key missing
+// from the structs is dropped without error (this happened to match_type,
+// address_lines, and formatted_street).
+//
+// The fixture is a real API response. To refresh it after an API change:
+//
+//	curl -s "https://api.geocod.io/v2/geocode?street=996C+East+St&street2=Unit+10&city=Walpole&state=MA&postal_code=02081&fields=census&api_key=$GEOCODIO_API_KEY" \
+//	  | python3 -m json.tool > internal/api/testdata/geocode_full_response.json
+func TestGeocodeResponseRoundTripsAllAPIFields(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "geocode_full_response.json"))
+	require.NoError(t, err)
+
+	var resp api.GeocodeResponse
+	require.NoError(t, json.Unmarshal(raw, &resp))
+
+	reencoded, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var original, output interface{}
+	require.NoError(t, json.Unmarshal(raw, &original))
+	require.NoError(t, json.Unmarshal(reencoded, &output))
+
+	originalPaths := map[string]bool{}
+	outputPaths := map[string]bool{}
+	collectKeyPaths(original, "", originalPaths)
+	collectKeyPaths(output, "", outputPaths)
+
+	var missing []string
+	for path := range originalPaths {
+		if !outputPaths[path] {
+			missing = append(missing, path)
+		}
+	}
+	sort.Strings(missing)
+
+	assert.Empty(t, missing,
+		"API response fields dropped by the structs in types.go; add the missing fields so CLI output includes them")
+}
+
+// collectKeyPaths records every object key path (e.g. "results[].match_type")
+// that holds a non-empty value. Empty values (null, "", 0, false, [], {}) are
+// skipped because the structs use omitempty, which legitimately omits them on
+// re-encode. Keys prefixed with "_" (e.g. _warnings) are API metadata that the
+// structs intentionally do not model.
+func collectKeyPaths(value interface{}, prefix string, out map[string]bool) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		for key, child := range typed {
+			if strings.HasPrefix(key, "_") {
+				continue
+			}
+			path := key
+			if prefix != "" {
+				path = prefix + "." + key
+			}
+			if isEmptyJSONValue(child) {
+				continue
+			}
+			out[path] = true
+			collectKeyPaths(child, path, out)
+		}
+	case []interface{}:
+		for _, item := range typed {
+			collectKeyPaths(item, prefix+"[]", out)
+		}
+	}
+}
+
+func isEmptyJSONValue(value interface{}) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case string:
+		return typed == ""
+	case float64:
+		return typed == 0
+	case bool:
+		return !typed
+	case []interface{}:
+		return len(typed) == 0
+	case map[string]interface{}:
+		return len(typed) == 0
+	}
+	return false
+}

--- a/internal/output/agent.go
+++ b/internal/output/agent.go
@@ -52,6 +52,9 @@ func (a *Agent) writeResultTable(r *api.GeocodeResult) {
 	fmt.Fprintf(a.w, "| Matched Address | %s |\n", r.FormattedAddress)
 	fmt.Fprintf(a.w, "| Coordinates | %.7f, %.7f |\n", r.Location.Lat, r.Location.Lng)
 	fmt.Fprintf(a.w, "| Accuracy | %s (%.2f) |\n", r.AccuracyType, r.Accuracy)
+	if r.MatchType != "" {
+		fmt.Fprintf(a.w, "| Match Type | %s |\n", r.MatchType)
+	}
 	if r.Source != "" {
 		fmt.Fprintf(a.w, "| Source | %s |\n", r.Source)
 	}

--- a/internal/output/agent_test.go
+++ b/internal/output/agent_test.go
@@ -36,6 +36,23 @@ func TestAgent_FormatGeocode(t *testing.T) {
 			},
 		},
 		{
+			name: "unit match type shown",
+			resp: &api.GeocodeResponse{
+				Results: []api.GeocodeResult{
+					{
+						FormattedAddress: "996C East St, Apt 10, Walpole, MA 02081",
+						Location:         api.Location{Lat: 42.146821, Lng: -71.254055},
+						Accuracy:         1.0,
+						AccuracyType:     "rooftop",
+						MatchType:        "unit",
+					},
+				},
+			},
+			wantContains: []string{
+				"| Match Type | unit |",
+			},
+		},
+		{
 			name: "multiple results",
 			resp: &api.GeocodeResponse{
 				Results: []api.GeocodeResult{

--- a/internal/output/human.go
+++ b/internal/output/human.go
@@ -56,6 +56,9 @@ func (h *Human) formatResult(r *api.GeocodeResult, num, total int) {
 	h.printField("Coordinates", fmt.Sprintf("%.7f, %.7f", r.Location.Lat, r.Location.Lng))
 	h.printField("Accuracy", fmt.Sprintf("%s (%.2f)", r.AccuracyType, r.Accuracy))
 
+	if r.MatchType != "" {
+		h.printField("Match Type", r.MatchType)
+	}
 	if r.Source != "" {
 		h.printField("Source", r.Source)
 	}

--- a/internal/output/human_test.go
+++ b/internal/output/human_test.go
@@ -30,6 +30,21 @@ func TestHuman_FormatGeocode(t *testing.T) {
 			wantContains: []string{"1600 Pennsylvania Ave NW", "38.8977", "rooftop"},
 		},
 		{
+			name: "unit match type shown",
+			resp: &api.GeocodeResponse{
+				Results: []api.GeocodeResult{
+					{
+						FormattedAddress: "996C East St, Apt 10, Walpole, MA 02081",
+						Location:         api.Location{Lat: 42.146821, Lng: -71.254055},
+						Accuracy:         1.0,
+						AccuracyType:     "rooftop",
+						MatchType:        "unit",
+					},
+				},
+			},
+			wantContains: []string{"Match Type", "unit"},
+		},
+		{
 			name: "multiple results",
 			resp: &api.GeocodeResponse{
 				Results: []api.GeocodeResult{


### PR DESCRIPTION
## Summary

The CLI decodes API responses into typed structs and re-encodes them for output, so any response key not declared on a struct is silently dropped. Three fields were missing:

- `match_type` (shipped with the API v1.11 unit-level geocoding work — `stable_address_key` from the same release was added, this one was missed)
- `address_lines`
- `address_components.formatted_street`

This affected `geocode`, `reverse`, and batch output in all formats (`lists download` was never affected since it writes the server's bytes straight to disk).

## Changes

- Add the three missing fields to `GeocodeResult` / `AddressComponents`
- Show `Match Type` after `Accuracy` in human and agent output when present (JSON output picks the fields up automatically)
- Add a round-trip regression test: a captured v2 response is decoded and re-encoded, and every non-empty key path must survive. Removing any struct field now fails the test naming the exact lost path, so future API fields can't silently vanish again. The test comment documents the curl command to refresh the fixture on API bumps.

## Verification

- Full test suite, `go vet`, `gofmt` clean
- Live check against production: `geocodio geocode "996C East St, Unit 10, Walpole, MA 02081"` now shows `Match Type: unit`; raw API and CLI output key sets diff clean